### PR TITLE
어르신 정보 / 건강정보 화면 구현 및 2차 병합

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/MainActivity.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.navigation.compose.rememberNavController
 import com.konkuk.medicarecall.navigation.BottomNavItem
 import com.konkuk.medicarecall.navigation.NavGraph
 import com.konkuk.medicarecall.ui.login_info.viewmodel.LoginViewModel
+import com.konkuk.medicarecall.ui.login_senior.LoginSeniorViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 
 class MainActivity : ComponentActivity() {
@@ -68,6 +69,7 @@ class MainActivity : ComponentActivity() {
                 var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
 
                 val loginViewModel: LoginViewModel = viewModel()
+                val loginSeniorViewModel: LoginSeniorViewModel = viewModel()
                 val bottomBarRoutes = listOf("home", "statistics", "settings")
 
 
@@ -133,6 +135,7 @@ class MainActivity : ComponentActivity() {
                     NavGraph(
                         navController = navController,
                         loginViewModel = loginViewModel,
+                        loginSeniorViewModel = loginSeniorViewModel,
                         modifier = Modifier
                             .padding(innerPadding)
                     )

--- a/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -19,6 +20,7 @@ import com.konkuk.medicarecall.ui.login_senior.screen.LoginSeniorInfoScreen
 import com.konkuk.medicarecall.ui.login_info.screen.LoginStartScreen
 import com.konkuk.medicarecall.ui.login_info.screen.LoginVerificationScreen
 import com.konkuk.medicarecall.ui.login_info.viewmodel.LoginViewModel
+import com.konkuk.medicarecall.ui.login_senior.LoginSeniorViewModel
 import com.konkuk.medicarecall.ui.login_senior.screen.LoginSeniorMedInfoScreen
 import com.konkuk.medicarecall.ui.settings.screen.SettingsScreen
 import com.konkuk.medicarecall.ui.statistics.screen.StatisticsScreen
@@ -28,6 +30,7 @@ import com.konkuk.medicarecall.ui.statistics.screen.StatisticsScreen
 fun NavGraph(
     navController: NavHostController,
     loginViewModel: LoginViewModel,
+    loginSeniorViewModel: LoginSeniorViewModel,
     modifier: Modifier = Modifier
 ) {
     val loginState = loginViewModel.loginState.collectAsState()
@@ -65,6 +68,8 @@ fun NavGraph(
         }
 
         navigation(startDestination = Route.LoginStart.route, route = "login") {
+
+
             composable(route = Route.LoginStart.route) {
                 LoginStartScreen(navController, loginViewModel)
             }
@@ -78,10 +83,10 @@ fun NavGraph(
                 LoginMyInfoScreen(navController, loginViewModel)
             }
             composable(route = Route.LoginSeniorInfoScreen.route) {
-                LoginSeniorInfoScreen(navController, loginViewModel)
+                LoginSeniorInfoScreen(navController, loginSeniorViewModel)
             }
             composable(route = Route.LoginSeniorMedInfoScreen.route) {
-                LoginSeniorMedInfoScreen(navController)
+                LoginSeniorMedInfoScreen(navController, loginSeniorViewModel)
             }
         }
         composable(route = Route.HomeMealDetail.route) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/component/DefaultDropDown.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/component/DefaultDropDown.kt
@@ -1,6 +1,5 @@
 package com.konkuk.medicarecall.ui.component
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -37,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.R
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow
-import kotlinx.coroutines.Delay
 import kotlinx.coroutines.delay
 
 @Composable
@@ -46,6 +44,7 @@ fun <T> DefaultDropdown(
     placeHolder: String,
     category: String? = null,
     scrollState: ScrollState,
+    onOptionSelect: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
 
@@ -152,6 +151,7 @@ fun <T> DefaultDropdown(
                                 }
                                 .clickable(onClick = {
                                     selectedOption = item.toString()
+                                    onOptionSelect(selectedOption!!)
                                     showDropdown = false
                                 }),
                         ) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/LoginSeniorViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/LoginSeniorViewModel.kt
@@ -1,11 +1,14 @@
 package com.konkuk.medicarecall.ui.login_senior
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
 class LoginSeniorViewModel : ViewModel() {
+
+    // 어르신 정보 화면
 
 
     var name by mutableStateOf("")
@@ -33,5 +36,14 @@ class LoginSeniorViewModel : ViewModel() {
     fun onGenderChanged(new: Boolean?) {
         isMale = new
     }
+
+    // 건강정보 화면
+    var selectedSenior by mutableIntStateOf(0)
+        private set
+
+    fun onSeniorChanged(new: Int) {
+        selectedSenior = new
+    }
+
 
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/LoginSeniorViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/LoginSeniorViewModel.kt
@@ -1,0 +1,37 @@
+package com.konkuk.medicarecall.ui.login_senior
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class LoginSeniorViewModel : ViewModel() {
+
+
+    var name by mutableStateOf("")
+        private set
+    var dateOfBirth by mutableStateOf("")
+        private set
+
+    var isMale by mutableStateOf<Boolean?>(null)
+        private set
+    var phoneNumber by mutableStateOf("")
+        private set
+
+    fun onPhoneNumberChanged(new: String) {
+        phoneNumber = new
+    }
+
+    fun onNameChanged(new: String) {
+        name = new
+    }
+
+    fun onDOBChanged(new: String) {
+        dateOfBirth = new
+    }
+
+    fun onGenderChanged(new: Boolean?) {
+        isMale = new
+    }
+
+}

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorInfoScreen.kt
@@ -34,6 +34,7 @@ import com.konkuk.medicarecall.ui.component.GenderToggleButton
 import com.konkuk.medicarecall.ui.login_info.component.TopBar
 import com.konkuk.medicarecall.ui.login_info.uistate.LoginUiState
 import com.konkuk.medicarecall.ui.login_info.viewmodel.LoginViewModel
+import com.konkuk.medicarecall.ui.login_senior.LoginSeniorViewModel
 import com.konkuk.medicarecall.ui.model.CTAButtonType
 import com.konkuk.medicarecall.ui.model.RelationshipType
 import com.konkuk.medicarecall.ui.model.SeniorLivingType
@@ -44,7 +45,7 @@ import com.konkuk.medicarecall.ui.util.PhoneNumberVisualTransformation
 @Composable
 fun LoginSeniorInfoScreen(
     navController: NavController,
-    loginViewModel: LoginViewModel,
+    loginSeniorViewModel: LoginSeniorViewModel,
     modifier: Modifier = Modifier
 ) {
 
@@ -70,15 +71,18 @@ fun LoginSeniorInfoScreen(
         Spacer(Modifier.height(40.dp))
         Column {
             DefaultTextField(
-                value = "",
-                onValueChange = {},
+                value = loginSeniorViewModel.name,
+                onValueChange = { loginSeniorViewModel.onNameChanged(it) },
                 category = "이름",
                 placeHolder = "이름"
             )
             Spacer(Modifier.height(20.dp))
             DefaultTextField(
-                "",
-                { },
+                loginSeniorViewModel.dateOfBirth,
+                { input ->
+                    val filtered = input.filter { it.isDigit() }.take(8)
+                    loginSeniorViewModel.onDOBChanged(filtered)
+                },
                 category = "생년월일",
                 placeHolder = "YYYY / MM / DD",
                 keyboardType = KeyboardType.Number,
@@ -92,12 +96,19 @@ fun LoginSeniorInfoScreen(
                     style = MediCareCallTheme.typography.M_17
                 )
 
-                GenderToggleButton(null) { }
+                GenderToggleButton(loginSeniorViewModel.isMale) {
+                    loginSeniorViewModel.onGenderChanged(
+                        it
+                    )
+                }
             }
             Spacer(Modifier.height(20.dp))
             DefaultTextField(
-                "",
-                { },
+                loginSeniorViewModel.phoneNumber,
+                { input ->
+                    val filtered = input.filter { it.isDigit() }.take(11)
+                    loginSeniorViewModel.onPhoneNumberChanged(filtered)
+                },
                 category = "휴대폰 번호",
                 placeHolder = "010-1234-5678",
                 keyboardType = KeyboardType.Number,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -4,6 +4,7 @@ import android.R.attr.onClick
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,18 +12,24 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.konkuk.medicarecall.ui.component.CTAButton
 import com.konkuk.medicarecall.ui.component.ChipItem
 import com.konkuk.medicarecall.ui.component.DefaultDropdown
+import com.konkuk.medicarecall.ui.component.IllnessInfoItem
 import com.konkuk.medicarecall.ui.component.MedInfoItem
 import com.konkuk.medicarecall.ui.login_info.component.TopBar
 import com.konkuk.medicarecall.ui.login_senior.LoginSeniorViewModel
@@ -65,29 +72,36 @@ fun LoginSeniorMedInfoScreen(
             )
         ) // 임시, TODO: 추후 서버에서 데이터 받아와야 함
 
+        var selectedIndex by remember { mutableStateOf<Int?>(null) }
         Row {
-            seniorList.forEach { senior ->
-                val selected = false
+            seniorList.forEachIndexed { index, senior ->
                 OutlinedButton(
                     onClick = {
-
+                        selectedIndex = index
                     },
                     colors = ButtonDefaults.outlinedButtonColors(
-                        containerColor = if (selected) MediCareCallTheme.colors.main else MediCareCallTheme.colors.white,
-                        contentColor = if (selected) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.gray2,
-
-                        ),
-                    shape = RoundedCornerShape(100.dp),
-                    border = BorderStroke(
-                        width = if (selected) 0.dp else (1.2).dp,
-                        color = if (selected) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2
+                        containerColor = if (index == selectedIndex) MediCareCallTheme.colors.main else MediCareCallTheme.colors.white,
+                        contentColor = if (index == selectedIndex) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.gray2,
                     ),
+                    shape = CircleShape,
+                    border = BorderStroke(
+                        width = if (index == selectedIndex) 0.dp else (1.2).dp,
+                        color = if (index == selectedIndex) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2
+                    ),
+                    contentPadding = PaddingValues(0.dp),
+
                 ) {
-                    Text(text = senior.name, style = MediCareCallTheme.typography.R_14)
+                    Text(
+                        text = senior.name,
+                        style = MediCareCallTheme.typography.R_14,
+                        color = if (index == selectedIndex) MediCareCallTheme.colors.white else MediCareCallTheme.colors.gray5
+                    )
                 }
                 Spacer(modifier = Modifier.width(8.dp)) // 버튼 간격
             }
         }
+        Spacer(Modifier.height(20.dp))
+        IllnessInfoItem()
         Spacer(Modifier.height(20.dp))
 
         MedInfoItem()

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -3,6 +3,7 @@ package com.konkuk.medicarecall.ui.login_senior.screen
 import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -118,7 +119,10 @@ fun LoginSeniorMedInfoScreen(
         var healthIssueList = remember { mutableStateListOf<String>() }
         Log.d("hel", "테스트")
         if (healthIssueList.isNotEmpty()) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 healthIssueList.forEach { healthIssue ->
                     ChipItem(healthIssue) {
                         healthIssueList.remove(healthIssue)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -1,8 +1,9 @@
 package com.konkuk.medicarecall.ui.login_senior.screen
 
-import android.R.attr.onClick
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,13 +14,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -90,7 +91,7 @@ fun LoginSeniorMedInfoScreen(
                     ),
                     contentPadding = PaddingValues(0.dp),
 
-                ) {
+                    ) {
                     Text(
                         text = senior.name,
                         style = MediCareCallTheme.typography.R_14,
@@ -113,15 +114,27 @@ fun LoginSeniorMedInfoScreen(
             style = MediCareCallTheme.typography.M_17
         )
         Spacer(Modifier.height(10.dp))
-        ChipItem("수면문제", {})
-        Spacer(Modifier.height(10.dp))
+
+        var healthIssueList = remember { mutableStateListOf<String>() }
+        Log.d("hel", "테스트")
+        if (healthIssueList.isNotEmpty()) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                healthIssueList.forEach { healthIssue ->
+                    ChipItem(healthIssue) {
+                        healthIssueList.remove(healthIssue)
+                    }
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+        }
 
 
         DefaultDropdown(
             HealthIssueType.values().map { it.displayName }.toList(),
             "특이사항 선택하기",
             null,
-            scrollState
+            scrollState,
+            { healthIssueList.add(it) }
         )
         CTAButton(CTAButtonType.GREEN, "다음", {}, Modifier.padding(top = 30.dp, bottom = 20.dp))
     }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -25,6 +25,7 @@ import com.konkuk.medicarecall.ui.component.ChipItem
 import com.konkuk.medicarecall.ui.component.DefaultDropdown
 import com.konkuk.medicarecall.ui.component.MedInfoItem
 import com.konkuk.medicarecall.ui.login_info.component.TopBar
+import com.konkuk.medicarecall.ui.login_senior.LoginSeniorViewModel
 import com.konkuk.medicarecall.ui.model.CTAButtonType
 import com.konkuk.medicarecall.ui.model.HealthIssueType
 import com.konkuk.medicarecall.ui.model.SeniorData
@@ -33,6 +34,7 @@ import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 @Composable
 fun LoginSeniorMedInfoScreen(
     navController: NavController,
+    loginSeniorViewModel: LoginSeniorViewModel,
     modifier: Modifier = Modifier
 ) {
     var scrollState = rememberScrollState()

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -73,21 +73,21 @@ fun LoginSeniorMedInfoScreen(
             )
         ) // 임시, TODO: 추후 서버에서 데이터 받아와야 함
 
-        var selectedIndex by remember { mutableStateOf<Int?>(null) }
+        // 상단 어르신 선택 Row
         Row {
             seniorList.forEachIndexed { index, senior ->
                 OutlinedButton(
                     onClick = {
-                        selectedIndex = index
+                        loginSeniorViewModel.onSeniorChanged(index)
                     },
                     colors = ButtonDefaults.outlinedButtonColors(
-                        containerColor = if (index == selectedIndex) MediCareCallTheme.colors.main else MediCareCallTheme.colors.white,
-                        contentColor = if (index == selectedIndex) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.gray2,
+                        containerColor = if (index == loginSeniorViewModel.selectedSenior) MediCareCallTheme.colors.main else MediCareCallTheme.colors.white,
+                        contentColor = if (index == loginSeniorViewModel.selectedSenior) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.gray2,
                     ),
                     shape = CircleShape,
                     border = BorderStroke(
-                        width = if (index == selectedIndex) 0.dp else (1.2).dp,
-                        color = if (index == selectedIndex) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2
+                        width = if (index == loginSeniorViewModel.selectedSenior) 0.dp else (1.2).dp,
+                        color = if (index == loginSeniorViewModel.selectedSenior) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2
                     ),
                     contentPadding = PaddingValues(0.dp),
 
@@ -95,7 +95,7 @@ fun LoginSeniorMedInfoScreen(
                     Text(
                         text = senior.name,
                         style = MediCareCallTheme.typography.R_14,
-                        color = if (index == selectedIndex) MediCareCallTheme.colors.white else MediCareCallTheme.colors.gray5
+                        color = if (index == loginSeniorViewModel.selectedSenior) MediCareCallTheme.colors.white else MediCareCallTheme.colors.gray5
                     )
                 }
                 Spacer(modifier = Modifier.width(8.dp)) // 버튼 간격

--- a/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/login_senior/screen/LoginSeniorMedInfoScreen.kt
@@ -1,16 +1,33 @@
 package com.konkuk.medicarecall.ui.login_senior.screen
 
+import android.R.attr.onClick
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.konkuk.medicarecall.ui.component.CTAButton
+import com.konkuk.medicarecall.ui.component.ChipItem
+import com.konkuk.medicarecall.ui.component.DefaultDropdown
+import com.konkuk.medicarecall.ui.component.MedInfoItem
 import com.konkuk.medicarecall.ui.login_info.component.TopBar
+import com.konkuk.medicarecall.ui.model.CTAButtonType
+import com.konkuk.medicarecall.ui.model.HealthIssueType
+import com.konkuk.medicarecall.ui.model.SeniorData
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 
 @Composable
@@ -30,5 +47,66 @@ fun LoginSeniorMedInfoScreen(
         TopBar(onClick = {
             navController.popBackStack()
         })
+        Spacer(Modifier.height(30.dp))
+        Text(
+            "건강정보 등록하기",
+            style = MediCareCallTheme.typography.B_26,
+            color = MediCareCallTheme.colors.black
+        )
+        Spacer(Modifier.height(20.dp))
+        var seniorList = listOf(
+            SeniorData(
+                1, "김옥자"
+            ),
+            SeniorData(
+                2, "박막례"
+            )
+        ) // 임시, TODO: 추후 서버에서 데이터 받아와야 함
+
+        Row {
+            seniorList.forEach { senior ->
+                val selected = false
+                OutlinedButton(
+                    onClick = {
+
+                    },
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        containerColor = if (selected) MediCareCallTheme.colors.main else MediCareCallTheme.colors.white,
+                        contentColor = if (selected) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.gray2,
+
+                        ),
+                    shape = RoundedCornerShape(100.dp),
+                    border = BorderStroke(
+                        width = if (selected) 0.dp else (1.2).dp,
+                        color = if (selected) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2
+                    ),
+                ) {
+                    Text(text = senior.name, style = MediCareCallTheme.typography.R_14)
+                }
+                Spacer(modifier = Modifier.width(8.dp)) // 버튼 간격
+            }
+        }
+        Spacer(Modifier.height(20.dp))
+
+        MedInfoItem()
+
+        Spacer(Modifier.height(20.dp))
+        Text(
+            "특이사항",
+            color = MediCareCallTheme.colors.gray7,
+            style = MediCareCallTheme.typography.M_17
+        )
+        Spacer(Modifier.height(10.dp))
+        ChipItem("수면문제", {})
+        Spacer(Modifier.height(10.dp))
+
+
+        DefaultDropdown(
+            HealthIssueType.values().map { it.displayName }.toList(),
+            "특이사항 선택하기",
+            null,
+            scrollState
+        )
+        CTAButton(CTAButtonType.GREEN, "다음", {}, Modifier.padding(top = 30.dp, bottom = 20.dp))
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/model/HealthIssueType.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/model/HealthIssueType.kt
@@ -1,0 +1,15 @@
+package com.konkuk.medicarecall.ui.model
+
+enum class HealthIssueType(val displayName: String) {
+    INSOMNIA("불면증 / 수면장애"),
+    FORGET_MEDICATION("약 자주 잊음"),
+    DIFFICULTY_WALKING("보행 불편"),
+    HEARING_LOSS("청력 저하"),
+    SUSPECTED_COGNITIVE_DECLINE("인지저하 의심"),
+    MOOD_SWINGS("감정기복"),
+    RECENT_SPOUSE_DEATH("최근 배우자 사망"),
+    SMOKING("흡연"),
+    DRINKING("음주"),
+    ALCOHOL_ADDICTION("알콜중독"),
+    VISUAL_IMPAIRMENT("시각장애"),
+}

--- a/app/src/main/java/com/konkuk/medicarecall/ui/model/SeniorData.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/model/SeniorData.kt
@@ -1,0 +1,6 @@
+package com.konkuk.medicarecall.ui.model
+
+data class SeniorData(
+    val id: Int,
+    val name: String,
+)


### PR DESCRIPTION
구현 영상은 디스코드 데일리 스크럼 채널에 올린 영상 확인해보시면 될 거 같습니다!

다만 드롭다운이나 복약 정보 등 공통 컴포넌트에서 UI적인 부분이나 ViewModel과의 연동 관련해서 기능적으로 수정할 점이 있어서 그 부분 병합 후에 수정해야 할 것 같습니다.
 
현재 제가 체크한 이슈 혹은 수정 요망 사항은 다음과 같습니다.
- 질환 정보 컴포넌트에 질환 정보가 등록되면 과도하게 여백이 생기는 문제
- 복약 정보에서 약 하나를 추가하고 나면 아침 / 점심 / 저녁 중 선택이 풀리는 문제
- 복약 정보에서 없던 공간을 ChipItem이 차지할 때 키보드 윗부분 UI가 올바르게 표현되지 않는 문제
<img width="370" height="808" alt="image" src="https://github.com/user-attachments/assets/a5df92de-491e-4c79-9707-e6e9358a0652" />

- 특이사항 드롭다운에서 선택시 Value가 남아있는 문제 ( 드롭다운에서는 value 인자를 받고, 실제 값은 viewmodel에서 관리해야 할 거 같습니다 )
- 드롭다운에서 5개의 아이템만 나오게 하는 방식이 현재는 215dp를 최대 크기로 잡았는데, 이런 방식은 기기마다 나오는 아이템의 수가 차이가 있을 수 있습니다. 