### PR TITLE
[Refactor] 혈당 그래프 스크롤 및 불러오기 방식 변경

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetail.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetail.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -83,6 +84,9 @@ fun GlucoseDetail(
 
     val coroutineScope = rememberCoroutineScope()
 
+    // 로딩 요청 중복 방지를 위한 플래그
+    val isRequestingMore = remember { mutableStateOf(false) }
+
     // 데이터 새로고침 로직
     val refreshData = remember(viewModel) {
         {
@@ -106,14 +110,27 @@ fun GlucoseDetail(
     }
 
 
-    // 무한 스크롤
-    LaunchedEffect(scrollState.value) {
-        Log.d("scroll", "${scrollState.value}")
-        if (scrollState.value > scrollState.maxValue - 250 && elderId != null && !uiState.isLoading && uiState.hasNext) {
+    // 무한 스크롤 (더 빠른 트리거와 중복 요청 방지)
+    LaunchedEffect(scrollState.value, scrollState.maxValue) {
+        Log.d("scroll", "value: ${scrollState.value}, max: ${scrollState.maxValue}, isLoading: ${uiState.isLoading}, hasNext: ${uiState.hasNext}")
+
+        // 더 일찍 트리거 (500dp 전에 미리 로딩)
+        val shouldLoad = scrollState.value > scrollState.maxValue - 500 || scrollState.maxValue <= 100
+
+        if (shouldLoad && elderId != null && !uiState.isLoading && uiState.hasNext && !isRequestingMore.value) {
+            isRequestingMore.value = true
             val currentTiming = uiState.selectedTiming
             val currentPage = counter.getValue(currentTiming)
-            viewModel.getGlucoseData(elderId!!, currentPage + 1, currentTiming)
+            Log.d("scroll", "Loading page ${currentPage + 1} for $currentTiming")
+            viewModel.getGlucoseData(elderId!!, currentPage + 1, currentTiming, false)
             counter[currentTiming] = currentPage + 1
+        }
+    }
+
+    // 로딩 완료 시 플래그 리셋
+    LaunchedEffect(uiState.isLoading) {
+        if (!uiState.isLoading) {
+            isRequestingMore.value = false
         }
     }
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -68,12 +68,18 @@ class GlucoseViewModel @Inject constructor(
 
                     // 현재 선택된 타이밍과 일치하는 경우에만 UI를 업데이트
                     if (_uiState.value.selectedTiming == type) {
+                        val newSelectedIndex = if (isRefresh) {
+                            // 새로고침이면 마지막 인덱스
+                            updatedDataList.lastIndex
+                        } else {
+                            // 페이지네이션이면 기존 선택 유지 (새 데이터가 앞에 추가되므로 인덱스 조정)
+                            _uiState.value.selectedIndex + newData.size
+                        }
+
                         _uiState.update {
-
-
                             it.copy(
                                 graphDataPoints = updatedDataList,
-                                selectedIndex = updatedDataList.lastIndex,
+                                selectedIndex = newSelectedIndex,
                                 hasNext = response.hasNextPage,
                             )
                         }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class GlucoseViewModel @Inject constructor(
-    private val glucoseRepository: GlucoseRepository
+    private val glucoseRepository: GlucoseRepository,
 ) : ViewModel() {
 
     private companion object {
@@ -37,7 +37,7 @@ class GlucoseViewModel @Inject constructor(
         elderId: Int,
         counter: Int,
         type: GlucoseTiming,
-        isRefresh: Boolean = false
+        isRefresh: Boolean = false,
     ) {
         _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
@@ -48,7 +48,7 @@ class GlucoseViewModel @Inject constructor(
                     val newData = processedData.map { record ->
                         GraphDataPoint(
                             date = LocalDate.parse(record.date),
-                            value = record.value.toFloat()
+                            value = record.value.toFloat(),
                         )
                     }
 
@@ -70,19 +70,11 @@ class GlucoseViewModel @Inject constructor(
                     if (_uiState.value.selectedTiming == type) {
                         _uiState.update {
 
-                            // 새로고침일 때만 선택 인덱스를 업데이트
-                            val newSelectedIndex = if (isRefresh) {
-                                // 가장 최근 날짜(마지막 인덱스)를 선택
-                                updatedDataList.lastIndex.takeIf { i -> i >= 0 } ?: -1
-                            } else {
-                                it.selectedIndex // 새로고침이 아니면 기존 선택 유지
-                            }
-
 
                             it.copy(
                                 graphDataPoints = updatedDataList,
-                                selectedIndex = newSelectedIndex,
-                                hasNext = response.hasNextPage
+                                selectedIndex = updatedDataList.lastIndex,
+                                hasNext = response.hasNextPage,
                             )
                         }
                     }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #112

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 혈당 화면 진입시 마지막 데이터가 선택돼있지 않는 문제를 해결했습니다.
- 데이터 로딩 타이밍을 더 앞당겨 그래프를 빠르게 스크롤하더라도 끊기지 않도록 수정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 무한 스크롤에서 중복 데이터 요청을 방지하도록 개선했습니다.
  - 스크롤 하단 인접 시점에 추가 로드가 안정적으로 동작하도록 트리거 조건을 조정했습니다.
  - 로딩 완료 후 상태를 제대로 초기화해 재요청 지연 문제를 완화했습니다.
  - 추가 데이터 로드는 필요한 조건을 확인한 후에만 실행되도록 강화했습니다.

- 사용자 경험 개선
  - 데이터 갱신(새로고침/페이지네이션) 시 최신 항목이 기본 선택되도록 일관성을 개선했습니다.
  - 스크롤 시 추가 로드 타이밍을 조정해 리스트 탐색이 더 매끄러워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->