### PR TITLE
[Refactor] 온보딩 상태 관리 방식 변경 #115

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/MainActivity.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/MainActivity.kt
@@ -40,7 +40,7 @@ import com.konkuk.medicarecall.navigation.BottomNavItem
 import com.konkuk.medicarecall.navigation.NavGraph
 import com.konkuk.medicarecall.navigation.navigateTopLevel
 import com.konkuk.medicarecall.ui.feature.login.info.viewmodel.LoginViewModel
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
+import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/navigation/NavGraph.kt
@@ -40,7 +40,7 @@ import com.konkuk.medicarecall.ui.feature.login.info.viewmodel.LoginViewModel
 import com.konkuk.medicarecall.ui.feature.login.payment.screen.FinishSplashScreen
 import com.konkuk.medicarecall.ui.feature.login.payment.screen.NaverPayScreen
 import com.konkuk.medicarecall.ui.feature.login.payment.screen.PaymentScreen
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
+import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
 import com.konkuk.medicarecall.ui.feature.login.senior.screen.LoginElderMedInfoScreen
 import com.konkuk.medicarecall.ui.feature.login.senior.screen.LoginElderScreen
 import com.konkuk.medicarecall.ui.feature.settings.screen.AnnouncementDetailScreen

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/DiseaseNamesItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/DiseaseNamesItem.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.Text
@@ -17,50 +16,54 @@ import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 
 @Composable
 fun DiseaseNamesItem(
-    inputText: MutableState<String>,
-    diseaseList: MutableList<String>,
-    modifier: Modifier = Modifier
+    inputText: String,
+    diseaseList: List<String>,
+    onTextChanged: (String) -> Unit,
+    onAddDisease: (String) -> Unit,
+    onRemoveChip: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
             text = "질환 정보",
             style = MediCareCallTheme.typography.M_17,
-            color = MediCareCallTheme.colors.gray7
+            color = MediCareCallTheme.colors.gray7,
         )
         if (diseaseList.isNotEmpty()) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
+                    .horizontalScroll(rememberScrollState()),
             ) {
-                diseaseList.forEachIndexed { index, disease ->
+                diseaseList.forEach { disease ->
                     ChipItem(
                         text = disease,
                         onRemove = {
-                            diseaseList.removeAt(index)
-                        }
+                            onRemoveChip(disease)
+                        },
                     )
                     Spacer(Modifier.width(10.dp))
                 }
             }
         }
         AddTextField(
-            inputText = inputText.value,
+            inputText = inputText,
             placeHolder = "질환명",
-            onTextChange = { inputText.value = it },
+            onTextChange = { onTextChanged(it) },
             clickPlus = {
-                if (inputText.value.trim().isNotBlank()) {
-                    if (diseaseList.contains(inputText.value)) {
-                        inputText.value = ""
+                if (inputText.trim().isNotBlank()) {
+                    if (diseaseList.contains(inputText)) {
+                        onTextChanged("")
                     } else {
 
-                        diseaseList.add(inputText.value)
-                        inputText.value = ""
+                        onAddDisease(inputText)
+                        onTextChanged("")
                     }
                 }
-            })
+            },
+        )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/GenderToggleButton.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/GenderToggleButton.kt
@@ -20,8 +20,8 @@ import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 
 @Composable
 fun GenderToggleButton(
-    isMale: Boolean?,
-    onGenderChange: (Boolean?) -> Unit
+    isMale: Boolean = true,
+    onGenderChange: (Boolean) -> Unit,
 ) {
 
     Row(
@@ -30,17 +30,17 @@ fun GenderToggleButton(
             .height(IntrinsicSize.Max)
             .clip(RoundedCornerShape(14.dp))
             .background(
-                MediCareCallTheme.colors.white
-            )
+                MediCareCallTheme.colors.white,
+            ),
     ) {
         Box(
             Modifier
                 .weight(1f)
-                .background(color = if (isMale == true) MediCareCallTheme.colors.g100 else MediCareCallTheme.colors.white)
+                .background(color = if (isMale) MediCareCallTheme.colors.g100 else MediCareCallTheme.colors.white)
                 .border(
                     width = 1.2.dp,
-                    color = if (isMale == true) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2,
-                    shape = RoundedCornerShape(topStart = 14.dp, bottomStart = 14.dp)
+                    color = if (isMale) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2,
+                    shape = RoundedCornerShape(topStart = 14.dp, bottomStart = 14.dp),
                 )
                 .clickable(
                     interactionSource = null,
@@ -48,40 +48,40 @@ fun GenderToggleButton(
                     onClick = { onGenderChange(true) },
                 ),
 
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Text(
                 "남성",
-                color = if (isMale == true) MediCareCallTheme.colors.main else MediCareCallTheme.colors.black,
-                style = if (isMale == true) MediCareCallTheme.typography.B_17 else MediCareCallTheme.typography.M_16,
+                color = if (isMale) MediCareCallTheme.colors.main else MediCareCallTheme.colors.black,
+                style = if (isMale) MediCareCallTheme.typography.B_17 else MediCareCallTheme.typography.M_16,
                 modifier = Modifier
-                    .padding(vertical = if (isMale == true) 15.5.dp else 16.dp)
+                    .padding(vertical = if (isMale) 15.5.dp else 16.dp),
             )
         }
         Box(
             Modifier
                 .weight(1f)
-                .background(color = if (isMale == false) MediCareCallTheme.colors.g100 else MediCareCallTheme.colors.white)
+                .background(color = if (!isMale) MediCareCallTheme.colors.g100 else MediCareCallTheme.colors.white)
                 .border(
                     width = 1.2.dp,
-                    color = if (isMale == false) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2,
-                    shape = RoundedCornerShape(topEnd = 14.dp, bottomEnd = 14.dp)
+                    color = if (!isMale) MediCareCallTheme.colors.main else MediCareCallTheme.colors.gray2,
+                    shape = RoundedCornerShape(topEnd = 14.dp, bottomEnd = 14.dp),
                 )
                 .clickable(
                     interactionSource = null,
                     indication = null,
-                    onClick = { onGenderChange(false) }
+                    onClick = { onGenderChange(false) },
                 ),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Text(
                 "여성",
-                color = if (isMale == false) MediCareCallTheme.colors.main else MediCareCallTheme.colors.black,
-                style = if (isMale == false) MediCareCallTheme.typography.B_17 else MediCareCallTheme.typography.M_16,
+                color = if (!isMale) MediCareCallTheme.colors.main else MediCareCallTheme.colors.black,
+                style = if (!isMale) MediCareCallTheme.typography.B_17 else MediCareCallTheme.typography.M_16,
                 modifier = Modifier
-                    .padding(vertical = if (isMale == false) 15.5.dp else 16.dp)
+                    .padding(vertical = if (!isMale) 15.5.dp else 16.dp),
 
-            )
+                )
         }
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
@@ -15,24 +15,18 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.konkuk.medicarecall.ui.type.MedicationTimeType
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import com.konkuk.medicarecall.ui.type.MedicationTimeType
 
 // 반복되는 UI를 재사용 가능한 함수로 추출
 @Composable
 private fun MedicationTimeSection(
     title: String,
-    medications: MutableList<String>, // 상태 변경이 가능해야 하므로 MutableList
-    onRemoveChip: (String) -> Unit
+    medications: List<String>,
+    onRemoveChip: (String) -> Unit,
 ) {
     // 약 목록이 비어있지 않을 때만 UI를 표시
     if (medications.isNotEmpty()) {
@@ -41,7 +35,7 @@ private fun MedicationTimeSection(
             Text(
                 text = title,
                 color = MediCareCallTheme.colors.gray5,
-                style = MediCareCallTheme.typography.R_15
+                style = MediCareCallTheme.typography.R_15,
             )
             Spacer(Modifier.height(10.dp))
             val scrollState = rememberScrollState()
@@ -49,7 +43,7 @@ private fun MedicationTimeSection(
                 modifier = Modifier
                     .padding(bottom = 16.dp)
                     .horizontalScroll(scrollState),
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 // 안전한 순회를 위해 toList()로 복사본을 만들어 사용
                 medications.toList().forEach { medication ->
@@ -65,10 +59,14 @@ private fun MedicationTimeSection(
 
 @Composable
 fun MedicationItem(
-    // Compose가 상태 변화를 감지할 수 있는 SnapshotStateMap 사용을 권장합니다.
-    medicationSchedule: MutableMap<MedicationTimeType, MutableList<String>>,
-    inputText: MutableState<String>,
-    modifier: Modifier = Modifier
+    medicationSchedule: Map<MedicationTimeType, List<String>>,
+    selectedList: List<MedicationTimeType>,
+    inputText: String,
+    onTextChange: (String) -> Unit,
+    onSelectTime: (MedicationTimeType) -> Unit,
+    onAddMedication: (MedicationTimeType, String) -> Unit,
+    onRemoveChip: (MedicationTimeType, String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     // UI에 표시할 제목을 Map으로 정의하여 관리 용이성을 높임
 
@@ -79,7 +77,7 @@ fun MedicationItem(
         Text(
             "복약 정보",
             color = MediCareCallTheme.colors.gray7,
-            style = MediCareCallTheme.typography.M_17
+            style = MediCareCallTheme.typography.M_17,
         )
         Spacer(Modifier.height(10.dp))
         MedicationTimeType.entries.forEach { timeType ->
@@ -91,11 +89,8 @@ fun MedicationItem(
                     title = timeType.time,
                     medications = medList,
                     onRemoveChip = { medicationToRemove ->
-                        // 상태를 직접 변경하여 Compose가 UI를 다시 그리도록 함
-                        val newList = medList.toMutableList()
-                        newList.remove(medicationToRemove)
-                        medicationSchedule[timeType] = newList
-                    }
+                        onRemoveChip(timeType, medicationToRemove)
+                    },
                 )
             }
         }
@@ -103,9 +98,8 @@ fun MedicationItem(
         if (!medicationSchedule.values.all { it.isEmpty() })
             Spacer(Modifier.height(20.dp))
 
-        val selectedList = remember { mutableStateListOf<MedicationTimeType>() }
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             MedicationTimeType.entries.forEach {
                 Box(
@@ -113,21 +107,21 @@ fun MedicationItem(
                         .clip(CircleShape)
                         .background(
                             color = if (it in selectedList) MediCareCallTheme.colors.main
-                            else MediCareCallTheme.colors.white
+                            else MediCareCallTheme.colors.white,
                         )
                         .border(
                             1.2.dp,
                             if (it in selectedList) MediCareCallTheme.colors.main
                             else MediCareCallTheme.colors.gray2,
-                            CircleShape
+                            CircleShape,
                         )
                         .clickable(
                             indication = null,
                             interactionSource = null,
                             onClick = {
-                                if (it in selectedList) selectedList.remove(it)
-                                else selectedList.add(it)
-                            })
+                                onSelectTime(it)
+                            },
+                        ),
                 ) {
                     Text(
                         it.time,
@@ -135,46 +129,28 @@ fun MedicationItem(
                         else MediCareCallTheme.colors.gray5,
                         style = if (it in selectedList) MediCareCallTheme.typography.SB_14
                         else MediCareCallTheme.typography.R_14,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp)
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
                     )
                 }
             }
         }
         Spacer(Modifier.height(20.dp))
         AddTextField(
-            inputText.value,
+            inputText,
             placeHolder = "예시) 당뇨약",
-            onTextChange = { inputText.value = it },
+            onTextChange = { onTextChange(it) },
             clickPlus = {
-                if (inputText.value.isNotBlank() && selectedList.isNotEmpty()) { // 입력값이 있을 때만 동작
+                if (inputText.isNotBlank() && selectedList.isNotEmpty()) { // 입력값이 있을 때만 동작
                     selectedList.forEach { time ->
-                        val currentList = medicationSchedule.getValue(time)
-                        if (inputText.value !in currentList) {
-                            val newList = currentList + inputText.value
-                            medicationSchedule[time] = newList.toMutableList()
-                        }
+                        onAddMedication(time, inputText)
                     }
 
                     // 사용성 개선: 약 추가 후 입력 필드와 선택된 시간 초기화
-                    inputText.value = ""
+                    onTextChange("")
                 }
 
-            }
+            },
         )
     }
 }
 
-@Preview(backgroundColor = 0xfffffff)
-@Composable
-private fun MedicationItemPrev() {
-    val inputText = remember { mutableStateOf("") }
-    val medSchedule = remember {
-        mutableStateMapOf(
-            MedicationTimeType.MORNING to
-                    mutableListOf("감기약", "당뇨약"),
-            MedicationTimeType.DINNER to
-                    mutableListOf("당뇨약")
-        )
-    }
-    MedicationItem(medSchedule, inputText)
-}

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/info/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/info/viewmodel/LoginViewModel.kt
@@ -27,7 +27,7 @@ class LoginViewModel @Inject constructor(
     private val verificationRepository: VerificationRepository,
     private val memberRegisterRepository: MemberRegisterRepository,
     private val dataStoreRepository: DataStoreRepository,
-    private val checkLoginStatusUseCase: CheckLoginStatusUseCase
+    private val checkLoginStatusUseCase: CheckLoginStatusUseCase,
 ) : ViewModel() {
     private val _navigationDestination = MutableStateFlow<NavigationDestination?>(null)
     val navigationDestination = _navigationDestination.asStateFlow()
@@ -47,7 +47,7 @@ class LoginViewModel @Inject constructor(
         private set
     var dateOfBirth by mutableStateOf("")
         private set
-    var isMale by mutableStateOf<Boolean?>(null)
+    var isMale by mutableStateOf<Boolean>(true)
         private set
 
     // 상태 변경 함수
@@ -67,7 +67,7 @@ class LoginViewModel @Inject constructor(
         dateOfBirth = new
     }
 
-    fun onGenderChanged(new: Boolean?) {
+    fun onGenderChanged(new: Boolean) {
         isMale = new
     }
 
@@ -83,7 +83,7 @@ class LoginViewModel @Inject constructor(
                     },
                     onFailure = { error ->
                         Log.d("httplog", "실패, ${error.message.toString()}")
-                    }
+                    },
                 )
             }
         }
@@ -100,7 +100,7 @@ class LoginViewModel @Inject constructor(
                     .onSuccess {
                         Log.d(
                             "httplog",
-                            "${it.message} ${it.memberStatus} 액세스토큰: ${it.accessToken} 리프레시 토큰: ${it.refreshToken} ${it.verified} ${it.token} "
+                            "${it.message} ${it.memberStatus} 액세스토큰: ${it.accessToken} 리프레시 토큰: ${it.refreshToken} ${it.verified} ${it.token} ",
                         )
                         isVerified = it.verified
                         if (isVerified) {
@@ -132,7 +132,7 @@ class LoginViewModel @Inject constructor(
                     token,
                     name,
                     birthDate.formatAsDate(),
-                    gender
+                    gender,
                 )
                     .onSuccess {
                         // 성공 로직

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderChip.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderChip.kt
@@ -1,0 +1,85 @@
+package com.konkuk.medicarecall.ui.feature.login.senior.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.medicarecall.R
+import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+
+@Composable
+fun ElderChip(
+    name: String,
+    selected: Boolean,
+    onRemove: () -> Unit,
+    onClick: () -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(100.dp),
+        color = if (selected) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.bg,
+        modifier = Modifier
+            .border(
+                (1.2).dp,
+                if (selected) MediCareCallTheme.colors.main
+                else MediCareCallTheme.colors.gray3,
+                shape = RoundedCornerShape(100.dp),
+            )
+            .clickable(
+                indication = null,
+                interactionSource = null,
+                onClick = onClick,
+            ),
+    ) {
+        Row(
+            Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                name,
+                color = if (selected) MediCareCallTheme.colors.main
+                else MediCareCallTheme.colors.gray3,
+                style = MediCareCallTheme.typography.R_14,
+                modifier = Modifier
+                    .defaultMinSize(minWidth = 38.dp)
+                    .padding(start = 4.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = "remove",
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable(
+                        indication = null,
+                        interactionSource = null,
+                        onClick = { onRemove() },
+                    ),
+                tint =
+                    if (selected) MediCareCallTheme.colors.main
+                    else MediCareCallTheme.colors.gray3,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ElderChipPreview() {
+    MediCareCallTheme {
+        ElderChip(name = "", selected = true, onClick = {}, onRemove = {})
+    }
+}

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderInputForm.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderInputForm.kt
@@ -1,178 +1,137 @@
 package com.konkuk.medicarecall.ui.feature.login.senior.component
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.ui.common.component.DefaultDropdown
 import com.konkuk.medicarecall.ui.common.component.DefaultTextField
 import com.konkuk.medicarecall.ui.common.component.GenderToggleButton
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
-import com.konkuk.medicarecall.ui.type.ElderResidenceType
-import com.konkuk.medicarecall.ui.type.RelationshipType
-import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
-import com.konkuk.medicarecall.ui.theme.figmaShadow
 import com.konkuk.medicarecall.ui.common.util.DateOfBirthVisualTransformation
 import com.konkuk.medicarecall.ui.common.util.PhoneNumberVisualTransformation
+import com.konkuk.medicarecall.ui.model.ElderData
+import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import com.konkuk.medicarecall.ui.type.ElderResidenceType
+import com.konkuk.medicarecall.ui.type.RelationshipType
 
 @Composable
 fun ElderInputForm(
-    loginElderViewModel: LoginElderViewModel,
     scrollState: ScrollState,
-    isExpanded: Boolean,
-    index: Int,
-    modifier: Modifier = Modifier
+    elderData: ElderData,
+    onNameChanged: (String) -> Unit,
+    onBirthDateChanged: (String) -> Unit,
+    onGenderChanged: (Boolean) -> Unit,
+    onPhoneNumberChanged: (String) -> Unit,
+    onRelationshipChange: (String) -> Unit,
+    onLivingTypeChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(
-        isExpanded,
-        enter = fadeIn() + expandVertically(),
-        exit = fadeOut() + shrinkVertically()
+    Column(
+        verticalArrangement = Arrangement.Center,
     ) {
-        Column(
-            verticalArrangement = Arrangement.Center
-        ) {
-            DefaultTextField(
-                value = loginElderViewModel.nameList[index],
-                onValueChange = { loginElderViewModel.onNameChanged(index, it) },
-                category = "이름",
-                placeHolder = "이름"
-            )
-            Spacer(Modifier.height(20.dp))
-            DefaultTextField(
-                loginElderViewModel.dateOfBirthList[index],
-                { input ->
-                    val filtered = input.filter { it.isDigit() }.take(8)
-                    loginElderViewModel.onDOBChanged(index, filtered)
-                },
-                category = "생년월일",
-                placeHolder = "YYYY / MM / DD",
-                keyboardType = KeyboardType.Number,
-                visualTransformation = DateOfBirthVisualTransformation(),
-                maxLength = 8
-            )
-            Spacer(Modifier.height(20.dp))
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                Text(
-                    "성별",
-                    color = MediCareCallTheme.colors.gray7,
-                    style = MediCareCallTheme.typography.M_17
-                )
-
-                GenderToggleButton(loginElderViewModel.isMaleBoolList[index]) {
-                    loginElderViewModel.onGenderChanged(
-                        index, it
-                    )
-                }
-            }
-            Spacer(Modifier.height(20.dp))
-            DefaultTextField(
-                loginElderViewModel.phoneNumberList[index],
-                { input ->
-                    val filtered = input.filter { it.isDigit() }.take(11)
-                    loginElderViewModel.onPhoneNumberChanged(index, filtered)
-                },
-                category = "휴대폰 번호",
-                placeHolder = "010-1234-5678",
-                keyboardType = KeyboardType.Number,
-                visualTransformation = PhoneNumberVisualTransformation(),
-                maxLength = 11
-            )
-            Spacer(Modifier.height(20.dp))
-
-
-            DefaultDropdown(
-                enumList = RelationshipType.entries.map { it.displayName }
-                    .toList(),
-                placeHolder = "관계 선택하기",
-                category = "어르신과의 관계",
-                scrollState,
-                { loginElderViewModel.onRelationshipChanged(index, it) },
-                loginElderViewModel.relationshipList[index]
+        DefaultTextField(
+            value = elderData.name,
+            onValueChange = { input ->
+                onNameChanged(input)
+            },
+            category = "이름",
+            placeHolder = "이름",
+        )
+        Spacer(Modifier.height(20.dp))
+        DefaultTextField(
+            elderData.birthDate,
+            { input ->
+                val filtered = input.filter { it.isDigit() }.take(8)
+                onBirthDateChanged(filtered)
+            },
+            category = "생년월일",
+            placeHolder = "YYYY / MM / DD",
+            keyboardType = KeyboardType.Number,
+            visualTransformation = DateOfBirthVisualTransformation(),
+            maxLength = 8,
+        )
+        Spacer(Modifier.height(20.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(
+                "성별",
+                color = MediCareCallTheme.colors.gray7,
+                style = MediCareCallTheme.typography.M_17,
             )
 
-
-            Spacer(Modifier.height(20.dp))
-
-            DefaultDropdown(
-                enumList = ElderResidenceType.entries.map { it.displayName }
-                    .toList(),
-                placeHolder = "거주방식을 선택해주세요",
-                category = "어르신 거주 방식",
-                scrollState,
-                { loginElderViewModel.onLivingTypeChanged(index, it) },
-                loginElderViewModel.livingTypeList[index]
-            )
-
-            Spacer(Modifier.height(20.dp))
-        }
-    }
-    if (!isExpanded) {
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .figmaShadow(MediCareCallTheme.shadow.shadow03)
-                .clip(
-                    RoundedCornerShape(14.dp)
-                )
-                .background(MediCareCallTheme.colors.white)
-                .clickable { loginElderViewModel.expandedFormIndex = index }
-        ) {
-            Column(
-                Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Row(
-                    Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        "${loginElderViewModel.nameList[index]} 님",
-                        color = MediCareCallTheme.colors.gray8,
-                        style = MediCareCallTheme.typography.SB_18
-                    )
-                    Text(
-                        "삭제하기",
-                        color = MediCareCallTheme.colors.negative,
-                        style = MediCareCallTheme.typography.R_14,
-                        modifier = Modifier.clickable(
-                            indication = null,
-                            interactionSource = null,
-                            onClick = {
-                                loginElderViewModel.elders--
-                                loginElderViewModel.expandedFormIndex = 0
-                            }
-                        )
-                    )
-                }
-                Text(
-                    loginElderViewModel.phoneNumberList[index].replaceFirst(
-                        Regex("(\\d{3})(\\d{4})(\\d{4})"),
-                        "$1-$2-$3"
-                    ),
-                    color = MediCareCallTheme.colors.gray4,
-                    style = MediCareCallTheme.typography.R_14
-                )
+            GenderToggleButton(elderData.gender) {
+                onGenderChanged(it)
             }
         }
-        Spacer(Modifier.height(30.dp))
+        Spacer(Modifier.height(20.dp))
+        DefaultTextField(
+            elderData.phoneNumber,
+            { input ->
+                val filtered = input.filter { it.isDigit() }.take(11)
+                onPhoneNumberChanged(filtered)
+            },
+            category = "휴대폰 번호",
+            placeHolder = "010-1234-5678",
+            keyboardType = KeyboardType.Number,
+            visualTransformation = PhoneNumberVisualTransformation(),
+            maxLength = 11,
+        )
+        Spacer(Modifier.height(20.dp))
+
+
+        DefaultDropdown(
+            enumList = RelationshipType.entries.map { it.displayName }
+                .toList(),
+            placeHolder = "관계 선택하기",
+            category = "어르신과의 관계",
+            scrollState,
+            { onRelationshipChange(it) },
+            elderData.relationship,
+        )
+
+
+        Spacer(Modifier.height(20.dp))
+
+        DefaultDropdown(
+            enumList = ElderResidenceType.entries.map { it.displayName }
+                .toList(),
+            placeHolder = "거주방식을 선택해주세요",
+            category = "어르신 거주 방식",
+            scrollState,
+            { onLivingTypeChanged(it) },
+            elderData.livingType,
+        )
+
+        Spacer(Modifier.height(20.dp))
     }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun ElderInputFormPreview() {
+    ElderInputForm(
+        scrollState = rememberScrollState(),
+        elderData = ElderData(
+            name = "김어르신",
+            birthDate = "19450101",
+            gender = true,
+            phoneNumber = "01012345678",
+            relationship = "자녀",
+            livingType = "혼자 거주",
+        ),
+        onNameChanged = {},
+        onBirthDateChanged = {},
+        onGenderChanged = {},
+        onPhoneNumberChanged = {},
+        onRelationshipChange = {},
+        onLivingTypeChanged = {},
+    )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderInputForm.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/component/ElderInputForm.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +35,7 @@ fun ElderInputForm(
     onRelationshipChange: (String) -> Unit,
     onLivingTypeChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
+    nameFocusRequester: FocusRequester? = null,
 ) {
     Column(
         verticalArrangement = Arrangement.Center,
@@ -44,6 +47,9 @@ fun ElderInputForm(
             },
             category = "이름",
             placeHolder = "이름",
+            textFieldModifier = if (nameFocusRequester != null)
+                Modifier.focusRequester(nameFocusRequester)
+            else Modifier,
         )
         Spacer(Modifier.height(20.dp))
         DefaultTextField(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +17,8 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -40,9 +43,9 @@ import com.konkuk.medicarecall.ui.common.component.CTAButton
 import com.konkuk.medicarecall.ui.common.component.DefaultSnackBar
 import com.konkuk.medicarecall.ui.common.util.isValidDate
 import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
+import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderChip
 import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderInputForm
 import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
-import com.konkuk.medicarecall.ui.model.ElderData
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.type.CTAButtonType
 import kotlinx.coroutines.launch
@@ -58,10 +61,9 @@ fun LoginElderScreen(
     val snackBarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
-    val elderList = loginElderViewModel.elderDataList
+    val uiState by loginElderViewModel.uiState.collectAsState()
+    val selectedIndex = uiState.selectedIndex
 
-    val selectedElderIndex by loginElderViewModel.selectedIndex.collectAsState()
-    val selectedElder = loginElderViewModel.elderDataList[selectedElderIndex]
 
     Box(
         modifier
@@ -91,16 +93,36 @@ fun LoginElderScreen(
                     style = MediCareCallTheme.typography.B_26,
                     color = MediCareCallTheme.colors.black,
                 )
+                if (uiState.eldersList.size != 1) {
+                    Spacer(Modifier.height(30.dp))
+                    LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+
+                        itemsIndexed(uiState.eldersList) { index, it ->
+                            ElderChip(
+                                name = it.name,
+                                selected = index == selectedIndex,
+                                onRemove = {
+                                    if (selectedIndex == uiState.eldersList.size - 1)
+                                        loginElderViewModel.selectElder(selectedIndex - 1)
+                                    loginElderViewModel.removeElder(index)
+                                },
+                                onClick = { loginElderViewModel.selectElder(index) },
+                            )
+
+                        }
+                    }
+                }
                 Spacer(Modifier.height(30.dp))
                 ElderInputForm(
                     scrollState = scrollState,
-                    elderData = selectedElder,
-                    onNameChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(name = it) },
-                    onBirthDateChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(birthDate = it) },
-                    onGenderChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(gender = it) },
-                    onPhoneNumberChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(phoneNumber = it) },
-                    onRelationshipChange = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(relationship = it) },
-                    onLivingTypeChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(livingType = it) },
+                    elderData = uiState.eldersList[selectedIndex],
+                    onNameChanged = { loginElderViewModel.updateElderName(it) },
+                    onBirthDateChanged = { loginElderViewModel.updateElderBirthDate(it) },
+                    onGenderChanged = { loginElderViewModel.updateElderGender(it) },
+                    onPhoneNumberChanged = { loginElderViewModel.updateElderPhoneNumber(it) },
+                    onRelationshipChange = { loginElderViewModel.updateElderRelationship(it) },
+                    onLivingTypeChanged = { loginElderViewModel.updateElderLivingType(it) },
+                    nameFocusRequester = nameFocusRequester,
                 )
 
 
@@ -134,8 +156,8 @@ fun LoginElderScreen(
                             indication = null,
                             interactionSource = interactionSource,
                         ) {
-                            if (loginElderViewModel.elderDataList.size < 5) {
-                                loginElderViewModel.elderDataList.add(ElderData())
+                            if (uiState.eldersList.size < 5) {
+                                loginElderViewModel.addElder()
                             } else {
                                 coroutineScope.launch {
                                     snackBarState.showSnackbar("어르신은 최대 5명까지 등록이 가능해요")
@@ -174,7 +196,7 @@ fun LoginElderScreen(
                     else CTAButtonType.DISABLED,
                     "다음",
                     {
-                        if (!loginElderViewModel.elderDataList.filter { it.name.isNotEmpty() }
+                        if (!uiState.eldersList.filter { it.name.isNotEmpty() }
                                 .all {
                                     it.name.matches(Regex("^[가-힣a-zA-Z]*$"))
                                 }
@@ -185,7 +207,7 @@ fun LoginElderScreen(
                                     duration = SnackbarDuration.Short,
                                 )
                             }
-                        else if (!loginElderViewModel.elderDataList.filter { it.birthDate.isNotEmpty() }
+                        else if (!uiState.eldersList.filter { it.birthDate.isNotEmpty() }
                                 .all {
                                     it.birthDate.isValidDate()
                                 })
@@ -195,7 +217,7 @@ fun LoginElderScreen(
                                     duration = SnackbarDuration.Short,
                                 )
                             }
-                        else if (!loginElderViewModel.elderDataList.filter { it.phoneNumber.isNotEmpty() }
+                        else if (!uiState.eldersList.filter { it.phoneNumber.isNotEmpty() }
                                 .all { it.phoneNumber.startsWith("010") })
                             coroutineScope.launch {
                                 snackBarState.showSnackbar(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -37,24 +38,30 @@ import com.konkuk.medicarecall.R
 import com.konkuk.medicarecall.navigation.Route
 import com.konkuk.medicarecall.ui.common.component.CTAButton
 import com.konkuk.medicarecall.ui.common.component.DefaultSnackBar
-import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderInputForm
-import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
-import com.konkuk.medicarecall.ui.type.CTAButtonType
-import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.common.util.isValidDate
+import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
+import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderInputForm
+import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
+import com.konkuk.medicarecall.ui.model.ElderData
+import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import com.konkuk.medicarecall.ui.type.CTAButtonType
 import kotlinx.coroutines.launch
 
 @Composable
 fun LoginElderScreen(
     navController: NavController,
     loginElderViewModel: LoginElderViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
 
     val scrollState = rememberScrollState()
     val snackBarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+
+    val elderList = loginElderViewModel.elderDataList
+
+    val selectedElderIndex by loginElderViewModel.selectedIndex.collectAsState()
+    val selectedElder = loginElderViewModel.elderDataList[selectedElderIndex]
 
     Box(
         modifier
@@ -65,32 +72,36 @@ fun LoginElderScreen(
             .imePadding(),
     ) {
         Column {
-            LoginBackButton({
-                navController.navigate(Route.LoginElderInfoScreen.route) {
-                    popUpTo(Route.LoginStart.route) { inclusive = false } // ← 스택 정리
-                    launchSingleTop = true
-                    restoreState = true
-                }
-            })
+            LoginBackButton(
+                {
+                    navController.navigate(Route.LoginElderInfoScreen.route) {
+                        popUpTo(Route.LoginStart.route) { inclusive = false } // ← 스택 정리
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+            )
             Column(
                 modifier
-                    .verticalScroll(scrollState)
+                    .verticalScroll(scrollState),
             ) {
                 Spacer(Modifier.height(20.dp))
                 Text(
                     "어르신 등록하기",
                     style = MediCareCallTheme.typography.B_26,
-                    color = MediCareCallTheme.colors.black
+                    color = MediCareCallTheme.colors.black,
                 )
                 Spacer(Modifier.height(30.dp))
-                repeat(loginElderViewModel.elders) { index ->
-                    ElderInputForm(
-                        loginElderViewModel,
-                        scrollState,
-                        index == loginElderViewModel.expandedFormIndex,
-                        index
-                    )
-                }
+                ElderInputForm(
+                    scrollState = scrollState,
+                    elderData = selectedElder,
+                    onNameChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(name = it) },
+                    onBirthDateChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(birthDate = it) },
+                    onGenderChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(gender = it) },
+                    onPhoneNumberChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(phoneNumber = it) },
+                    onRelationshipChange = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(relationship = it) },
+                    onLivingTypeChanged = { loginElderViewModel.elderDataList[selectedElderIndex] = selectedElder.copy(livingType = it) },
+                )
 
 
                 val interactionSource = remember { MutableInteractionSource() }
@@ -108,7 +119,7 @@ fun LoginElderScreen(
                                     MediCareCallTheme.colors.g200
                                 else
                                     MediCareCallTheme.colors.g50
-                            } else MediCareCallTheme.colors.gray1
+                            } else MediCareCallTheme.colors.gray1,
                         )
                         .border(
                             1.2.dp,
@@ -116,62 +127,34 @@ fun LoginElderScreen(
                                 MediCareCallTheme.colors.main
                             else
                                 MediCareCallTheme.colors.gray3,
-                            shape = RoundedCornerShape(14.dp)
+                            shape = RoundedCornerShape(14.dp),
                         )
                         .clickable(
                             enabled = loginElderViewModel.isInputComplete(),
                             indication = null,
-                            interactionSource = interactionSource
+                            interactionSource = interactionSource,
                         ) {
-                            if (loginElderViewModel.elders < 5) {
-                                loginElderViewModel.elders++
-                                loginElderViewModel.expandedFormIndex =
-                                    loginElderViewModel.elders - 1
-                                loginElderViewModel.onNameChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    ""
-                                )
-                                loginElderViewModel.onDOBChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    ""
-                                )
-                                loginElderViewModel.onRelationshipChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    ""
-                                )
-                                loginElderViewModel.onGenderChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    null
-                                )
-                                loginElderViewModel.onLivingTypeChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    ""
-                                )
-                                loginElderViewModel.onPhoneNumberChanged(
-                                    loginElderViewModel.expandedFormIndex,
-                                    ""
-                                )
-
-
+                            if (loginElderViewModel.elderDataList.size < 5) {
+                                loginElderViewModel.elderDataList.add(ElderData())
                             } else {
                                 coroutineScope.launch {
                                     snackBarState.showSnackbar("어르신은 최대 5명까지 등록이 가능해요")
 
                                 }
                             }
-                        }
+                        },
                 ) {
                     Row(
                         Modifier
                             .padding(vertical = 16.dp)
-                            .align(Alignment.Center)
+                            .align(Alignment.Center),
 
-                    ) {
+                        ) {
                         Icon(
                             painterResource(R.drawable.ic_plus), contentDescription = "플러스 아이콘",
                             tint = if (loginElderViewModel.isInputComplete())
                                 MediCareCallTheme.colors.main
-                            else MediCareCallTheme.colors.gray3
+                            else MediCareCallTheme.colors.gray3,
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(
@@ -179,7 +162,7 @@ fun LoginElderScreen(
                             color = if (loginElderViewModel.isInputComplete())
                                 MediCareCallTheme.colors.main
                             else MediCareCallTheme.colors.gray3,
-                            style = MediCareCallTheme.typography.B_17
+                            style = MediCareCallTheme.typography.B_17,
                         )
                     }
                 }
@@ -191,50 +174,49 @@ fun LoginElderScreen(
                     else CTAButtonType.DISABLED,
                     "다음",
                     {
-                        if (!loginElderViewModel.nameList.filter { it.isNotEmpty() }
+                        if (!loginElderViewModel.elderDataList.filter { it.name.isNotEmpty() }
                                 .all {
-                                    it.matches(Regex("^[가-힣a-zA-Z]*$"))
+                                    it.name.matches(Regex("^[가-힣a-zA-Z]*$"))
                                 }
                         )
                             coroutineScope.launch {
                                 snackBarState.showSnackbar(
                                     "이름을 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short
+                                    duration = SnackbarDuration.Short,
                                 )
                             }
-                        else if (!loginElderViewModel.dateOfBirthList.filter { it.isNotEmpty() }
+                        else if (!loginElderViewModel.elderDataList.filter { it.birthDate.isNotEmpty() }
                                 .all {
-                                    it.isValidDate()
+                                    it.birthDate.isValidDate()
                                 })
                             coroutineScope.launch {
                                 snackBarState.showSnackbar(
                                     "생년월일을 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short
+                                    duration = SnackbarDuration.Short,
                                 )
                             }
-                        else if (!loginElderViewModel.phoneNumberList.filter { it.isNotEmpty() }
-                                .all { it.startsWith("010") })
+                        else if (!loginElderViewModel.elderDataList.filter { it.phoneNumber.isNotEmpty() }
+                                .all { it.phoneNumber.startsWith("010") })
                             coroutineScope.launch {
                                 snackBarState.showSnackbar(
                                     "휴대폰 번호를 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short
+                                    duration = SnackbarDuration.Short,
                                 )
                             }
                         else {
-                            loginElderViewModel.createElderDataList()
                             navController.navigate(Route.LoginElderMedInfoScreen.route)
                         }
                     },
-                    modifier.padding(bottom = 20.dp)
+                    modifier.padding(bottom = 20.dp),
                 )
             }
         }
+
         DefaultSnackBar(
             snackBarState,
             Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 14.dp)
+                .padding(bottom = 14.dp),
         )
     }
-
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -236,6 +236,7 @@ fun LoginElderScreen(
                                 )
                             }
                         else {
+                            loginElderViewModel.initElderHealthData()
                             navController.navigate(Route.LoginElderMedInfoScreen.route)
                         }
                     },

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -41,7 +41,7 @@ import com.konkuk.medicarecall.ui.common.component.DefaultSnackBar
 import com.konkuk.medicarecall.ui.common.util.isValidDate
 import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
 import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderInputForm
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
+import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
 import com.konkuk.medicarecall.ui.model.ElderData
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.type.CTAButtonType

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -34,6 +35,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -48,6 +50,7 @@ import com.konkuk.medicarecall.ui.feature.login.senior.component.ElderInputForm
 import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.type.CTAButtonType
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -60,9 +63,16 @@ fun LoginElderScreen(
     val scrollState = rememberScrollState()
     val snackBarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val nameFocusRequester = remember { FocusRequester() }
 
     val uiState by loginElderViewModel.uiState.collectAsState()
     val selectedIndex = uiState.selectedIndex
+
+    LaunchedEffect(selectedIndex) {
+        nameFocusRequester.requestFocus()
+        delay(100L)
+        scrollState.animateScrollTo(0)
+    }
 
 
     Box(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -65,7 +65,7 @@ fun LoginElderScreen(
     val coroutineScope = rememberCoroutineScope()
     val nameFocusRequester = remember { FocusRequester() }
 
-    val uiState by loginElderViewModel.uiState.collectAsState()
+    val uiState by loginElderViewModel.elderUiState.collectAsState()
     val selectedIndex = uiState.selectedIndex
 
     LaunchedEffect(selectedIndex) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
@@ -36,7 +36,7 @@ import com.konkuk.medicarecall.ui.common.component.DefaultSnackBar
 import com.konkuk.medicarecall.ui.common.component.DiseaseNamesItem
 import com.konkuk.medicarecall.ui.common.component.MedicationItem
 import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
-import com.konkuk.medicarecall.ui.feature.login.senior.LoginElderViewModel
+import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
 import com.konkuk.medicarecall.ui.type.CTAButtonType
 import com.konkuk.medicarecall.ui.type.HealthIssueType
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -37,9 +39,9 @@ import com.konkuk.medicarecall.ui.common.component.DiseaseNamesItem
 import com.konkuk.medicarecall.ui.common.component.MedicationItem
 import com.konkuk.medicarecall.ui.feature.login.info.component.LoginBackButton
 import com.konkuk.medicarecall.ui.feature.login.senior.viewmodel.LoginElderViewModel
+import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.type.CTAButtonType
 import com.konkuk.medicarecall.ui.type.HealthIssueType
-import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -47,12 +49,17 @@ import kotlinx.coroutines.launch
 fun LoginElderMedInfoScreen(
     navController: NavController,
     loginElderViewModel: LoginElderViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
 
     val snackBarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+
+    val elderUiState by loginElderViewModel.elderUiState.collectAsState()
+
+    val uiState by loginElderViewModel.elderHealthUiState.collectAsState()
+    val selectedIndex = uiState.selectedIndex
 
     Box(
 
@@ -61,63 +68,63 @@ fun LoginElderMedInfoScreen(
             .background(MediCareCallTheme.colors.bg)
             .padding(horizontal = 20.dp)
             .systemBarsPadding()
-            .imePadding()
+            .imePadding(),
     ) {
         Column {
-            LoginBackButton({
-                navController.popBackStack()
-            })
+            LoginBackButton(
+                {
+                    navController.popBackStack()
+                },
+            )
             Column(
                 Modifier
-                    .verticalScroll(scrollState)
+                    .verticalScroll(scrollState),
             ) {
                 Spacer(Modifier.height(30.dp))
                 Text(
                     "건강정보 등록하기",
                     style = MediCareCallTheme.typography.B_26,
-                    color = MediCareCallTheme.colors.black
+                    color = MediCareCallTheme.colors.black,
                 )
                 Spacer(Modifier.height(20.dp))
 
                 val scrollState = rememberScrollState()
                 // 상단 어르신 선택 Row
                 Row(Modifier.horizontalScroll(scrollState)) {
-                    loginElderViewModel.elderDataList.forEachIndexed { index, elder ->
-
+                    elderUiState.eldersList.forEachIndexed { index, elder ->
                         Box(
                             Modifier
                                 .clip(shape = CircleShape)
                                 .background(
-                                    if (index == loginElderViewModel.selectedElder)
+                                    if (index == selectedIndex)
                                         MediCareCallTheme.colors.main
-                                    else MediCareCallTheme.colors.white
+                                    else MediCareCallTheme.colors.white,
                                 )
                                 .border(
                                     width = 1.2.dp,
-                                    color = if (index == loginElderViewModel.selectedElder)
+                                    color = if (index == selectedIndex)
                                         MediCareCallTheme.colors.main
                                     else MediCareCallTheme.colors.gray2,
-                                    shape = CircleShape
+                                    shape = CircleShape,
                                 )
                                 .clickable(
                                     interactionSource = null,
                                     indication = null,
                                     onClick = {
-                                        loginElderViewModel.onSelectedElderChanged(index)
+                                        loginElderViewModel.selectElderInHealth(index)
+                                    },
+                                ),
 
-                                    }
-                                )
-
-                        ) {
+                            ) {
                             Text(
                                 text = elder.name,
-                                style = if (index == loginElderViewModel.selectedElder)
+                                style = if (index == selectedIndex)
                                     MediCareCallTheme.typography.SB_14
                                 else MediCareCallTheme.typography.R_14,
-                                color = if (index == loginElderViewModel.selectedElder)
+                                color = if (index == selectedIndex)
                                     MediCareCallTheme.colors.white
                                 else MediCareCallTheme.colors.gray5,
-                                modifier = Modifier.padding(vertical = 8.dp, horizontal = 24.dp)
+                                modifier = Modifier.padding(vertical = 8.dp, horizontal = 24.dp),
                             )
                         }
                         Spacer(modifier = Modifier.width(8.dp)) // 버튼 간격
@@ -125,34 +132,44 @@ fun LoginElderMedInfoScreen(
                 }
                 Spacer(Modifier.height(20.dp))
                 DiseaseNamesItem(
-                    loginElderViewModel.diseaseInputText[loginElderViewModel.selectedElder],
-                    loginElderViewModel.diseaseList[loginElderViewModel.selectedElder]
+                    inputText = uiState.diseaseInputText,
+                    diseaseList = uiState.elderHealthList[selectedIndex].diseaseNames,
+                    onTextChanged = {
+                        loginElderViewModel.updateDiseasesText(it);
+                    },
+                    onRemoveChip = {
+                        loginElderViewModel.removeDisease(it)
+                    },
+                    onAddDisease = { loginElderViewModel.addDisease(it) },
                 )
                 Spacer(Modifier.height(20.dp))
 
                 MedicationItem(
-                    loginElderViewModel.medMap[loginElderViewModel.selectedElder],
-                    loginElderViewModel.medInputText[loginElderViewModel.selectedElder],
+                    medicationSchedule = uiState.elderHealthList[selectedIndex].medicationMap,
+                    inputText = uiState.medicationInputText,
+                    selectedList = uiState.selectedMedicationTimes,
+                    onTextChange = { loginElderViewModel.updateMedicationText(it) },
+                    onRemoveChip = { time, medicine -> loginElderViewModel.removeMedication(time, medicine) },
+                    onSelectTime = { loginElderViewModel.selectMedicationTime(it) },
+                    onAddMedication = { time, medicine -> loginElderViewModel.addMedication(time, medicine) },
                 )
 
                 Spacer(Modifier.height(20.dp))
                 Text(
                     "특이사항",
                     color = MediCareCallTheme.colors.gray7,
-                    style = MediCareCallTheme.typography.M_17
+                    style = MediCareCallTheme.typography.M_17,
                 )
                 Spacer(Modifier.height(10.dp))
 
-                if (loginElderViewModel.healthIssueList[loginElderViewModel.selectedElder].isNotEmpty()) {
+                if (uiState.elderHealthList[selectedIndex].notes.isNotEmpty()) {
                     Row(
                         Modifier.horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        loginElderViewModel.healthIssueList[loginElderViewModel.selectedElder].forEach { healthIssue ->
-                            ChipItem(healthIssue) {
-                                loginElderViewModel.healthIssueList[loginElderViewModel.selectedElder].remove(
-                                    healthIssue
-                                )
+                        uiState.elderHealthList[selectedIndex].notes.forEach { note ->
+                            ChipItem(note) {
+                                loginElderViewModel.removeHealthNote(note)
                             }
                         }
                     }
@@ -166,18 +183,14 @@ fun LoginElderMedInfoScreen(
                     null,
                     scrollState,
                     {
-                        if (it !in loginElderViewModel.healthIssueList[loginElderViewModel.selectedElder])
-                            loginElderViewModel.healthIssueList[loginElderViewModel.selectedElder].add(
-                                it
-                            )
-                    }
+                        loginElderViewModel.addHealthNote(it)
+                    },
                 )
                 CTAButton(
                     CTAButtonType.GREEN,
                     "다음",
                     {
                         coroutineScope.launch {
-                            loginElderViewModel.createElderHealthDataList()
                             loginElderViewModel.updateAllElders()
                             loginElderViewModel.updateAllEldersHealthInfo()
                             loginElderViewModel.postElderAndHealth()
@@ -189,7 +202,7 @@ fun LoginElderMedInfoScreen(
                             }
                         }
                     },
-                    Modifier.padding(top = 30.dp, bottom = 20.dp)
+                    Modifier.padding(top = 30.dp, bottom = 20.dp),
                 )
             }
         }
@@ -197,7 +210,7 @@ fun LoginElderMedInfoScreen(
             snackBarState,
             Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 14.dp)
+                .padding(bottom = 14.dp),
         )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderHealthUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderHealthUiState.kt
@@ -1,0 +1,12 @@
+package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
+
+import com.konkuk.medicarecall.ui.model.ElderHealthData
+import com.konkuk.medicarecall.ui.type.MedicationTimeType
+
+data class LoginElderHealthUiState(
+    val elderHealthList: List<ElderHealthData> = listOf(ElderHealthData()),
+    val selectedIndex: Int = 0,
+    val selectedMedicationTimes: List<MedicationTimeType> = emptyList(),
+    val diseaseInputText: String = "",
+    val medicationInputText: String = "",
+)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderUiState.kt
@@ -1,0 +1,5 @@
+package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
+
+data class LoginElderUiState(
+    val eldersList: List<String> = emptyList(),
+)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderUiState.kt
@@ -1,5 +1,8 @@
 package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
 
+import com.konkuk.medicarecall.ui.model.ElderData
+
 data class LoginElderUiState(
-    val eldersList: List<String> = emptyList(),
+    val eldersList: List<ElderData> = listOf(ElderData()),
+    val selectedIndex: Int = 0,
 )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -1,13 +1,9 @@
-package com.konkuk.medicarecall.ui.feature.login.senior
+package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
 
 import android.util.Log
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -18,6 +14,8 @@ import com.konkuk.medicarecall.ui.model.ElderData
 import com.konkuk.medicarecall.ui.model.ElderHealthData
 import com.konkuk.medicarecall.ui.type.MedicationTimeType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -25,77 +23,29 @@ import javax.inject.Inject
 class LoginElderViewModel @Inject constructor(
     private val elderRegisterRepository: ElderRegisterRepository,
     private val elderIdRepository: ElderIdRepository,
-    private val eldersInfoRepository: EldersInfoRepository
+    private val eldersInfoRepository: EldersInfoRepository,
 ) : ViewModel() {
     // 어르신 정보 화면
 
-    var expandedFormIndex by mutableIntStateOf(0)
-    var elders by mutableIntStateOf(1) // 추가된 어르신 수
+    private val _selectedIndex = MutableStateFlow(0)
+    val selectedIndex = _selectedIndex.asStateFlow()
 
 
-    var nameList = mutableStateListOf<String>().apply {
-        repeat(5) { add("") }
-    }
-        private set
-    var dateOfBirthList = mutableStateListOf<String>().apply {
-        repeat(5) { add("") }
-    }
-        private set
+    private val _elderDataList = MutableStateFlow<MutableList<ElderData>>()
+    val elderDataList = mutableStateListOf(
+        ElderData(),
+    )
 
-    var isMaleBoolList = mutableStateListOf<Boolean?>().apply {
-        repeat(5) { add(null) }
-    }
-        private set
-    var phoneNumberList = mutableStateListOf<String>().apply {
-        repeat(5) { add("") }
-    }
-        private set
-
-    var relationshipList = mutableStateListOf<String>().apply {
-        repeat(5) { add("") }
-    }
-        private set
-
-    var livingTypeList = mutableStateListOf<String>().apply {
-        repeat(5) { add("") }
-    }
-        private set
 
     fun isInputComplete(): Boolean {
-        return (0 until elders).all { i ->
-
-            nameList[i].isNotBlank() &&
-                    dateOfBirthList[i].length == 8 &&
-                    isMaleBoolList[i] != null &&
-                    phoneNumberList[i].length == 11 &&
-                    relationshipList[i].isNotBlank() &&
-                    livingTypeList[i].isNotBlank()
+        return elderDataList.all {
+            it.name.isNotBlank() &&
+                it.birthDate.length == 8 &&
+                it.phoneNumber.length == 11 &&
+                it.relationship.isNotBlank() &&
+                it.livingType.isNotBlank()
         }
 
-    }
-
-    fun onPhoneNumberChanged(index: Int, new: String) {
-        phoneNumberList[index] = new
-    }
-
-    fun onNameChanged(index: Int, new: String) {
-        nameList[index] = new
-    }
-
-    fun onDOBChanged(index: Int, new: String) {
-        dateOfBirthList[index] = new
-    }
-
-    fun onGenderChanged(index: Int, new: Boolean?) {
-        isMaleBoolList[index] = new
-    }
-
-    fun onRelationshipChanged(index: Int, new: String) {
-        relationshipList[index] = new
-    }
-
-    fun onLivingTypeChanged(index: Int, new: String) {
-        livingTypeList[index] = new
     }
 
     // 건강정보 화면
@@ -116,69 +66,19 @@ class LoginElderViewModel @Inject constructor(
     var healthIssueList = mutableStateListOf(mutableStateListOf<String>())
 
 
-    // 기타 데이터
-
-    val elderDataList = mutableStateListOf<ElderData>()
-    fun createElderDataList() {
-        elderDataList.apply {
-            for (index in 0 until elders) {
-                val currentId = getOrNull(index)?.id // 기존 id 유지
-
-                val elder = ElderData(
-                    nameList[index],
-                    dateOfBirthList[index],
-                    isMaleBoolList[index] ?: true,
-                    phoneNumberList[index],
-                    relationshipList[index],
-                    livingTypeList[index],
-                    currentId
-                )
-
-                if (index < size) {
-                    set(index, elder) // 기존 항목 덮어쓰기 (id 유지)
-                } else {
-                    add(elder)        // 새 어르신 추가
-                }
-            }
-
-            // 2. 입력 개수보다 리스트가 더 길면 → 뒤에 남은 항목 삭제
-            while (size > elders) {
-                removeAt(lastIndex)
-            }
-
-        }
-        initHealthData()
-    }
-
-    private fun initHealthData() {
-        repeat(elders - diseaseInputText.size) {
-            diseaseInputText.add(mutableStateOf(""))
-            diseaseList.add(mutableStateListOf())
-            medInputText.add(mutableStateOf(""))
-            medMap.add(
-                mutableStateMapOf(
-                    MedicationTimeType.MORNING to mutableListOf(),
-                    MedicationTimeType.LUNCH to mutableListOf(),
-                    MedicationTimeType.DINNER to mutableListOf()
-                )
-            )
-            healthIssueList.add(mutableStateListOf())
-        }
-    }
-
     val elderHealthDataList = mutableStateListOf<ElderHealthData>()
 
     fun createElderHealthDataList() {
 
         elderHealthDataList.apply {
-            repeat(elders) { index ->
+            repeat(elderDataList.size) { index ->
                 val currentId = getOrNull(index)?.id // 기존 id 보존
 
                 val healthData = ElderHealthData(
                     diseaseNames = diseaseList[index],
                     medicationMap = medMap[index],
                     notes = healthIssueList[index],
-                    id = currentId
+                    id = currentId,
                 )
 
                 if (index < size) {
@@ -195,9 +95,9 @@ class LoginElderViewModel @Inject constructor(
     fun postElderAndHealth() {
         viewModelScope.launch {
             elderRegisterRepository.registerElderAndHealth(
-                elders = elders,
+                elders = elderDataList.size,
                 elderInfoList = elderDataList,
-                elderHealthInfo = elderHealthDataList
+                elderHealthInfo = elderHealthDataList,
             )
                 .onSuccess {
                     Log.d("httplog", "어르신 및 건강정보 전부 등록 성공!")
@@ -216,7 +116,7 @@ class LoginElderViewModel @Inject constructor(
                 it.values.first() == elderDataList[index].id
             }.forEachIndexed { index, it ->
                 eldersInfoRepository.updateElder(
-                    it.values.first(), elderDataList[index]
+                    it.values.first(), elderDataList[index],
                 ).onSuccess {
                     Log.d("httplog", "어르신 재등록(수정) 성공")
                 }.onFailure { exception ->
@@ -240,7 +140,7 @@ class LoginElderViewModel @Inject constructor(
                 runCatching {
                     elderRegisterRepository.postElderHealthInfo(
                         it.values.first(),
-                        elderHealthDataList[index]
+                        elderHealthDataList[index],
                     )
                 }.onSuccess {
                     Log.d("httplog", "어르신 건강정보 재등록(수정) 성공")
@@ -249,5 +149,3 @@ class LoginElderViewModel @Inject constructor(
         }
     }
 }
-
-

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -2,8 +2,10 @@ package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
 
 import android.util.Log
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -15,6 +17,7 @@ import com.konkuk.medicarecall.ui.model.ElderHealthData
 import com.konkuk.medicarecall.ui.type.MedicationTimeType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,23 +30,81 @@ class LoginElderViewModel @Inject constructor(
 ) : ViewModel() {
     // 어르신 정보 화면
 
-    private val _selectedIndex = MutableStateFlow(0)
-    val selectedIndex = _selectedIndex.asStateFlow()
+    private val _uiState = MutableStateFlow(LoginElderUiState())
+    val uiState: StateFlow<LoginElderUiState> = _uiState.asStateFlow()
 
 
-    private val _elderDataList = MutableStateFlow<MutableList<ElderData>>()
-    val elderDataList = mutableStateListOf(
-        ElderData(),
-    )
+    fun updateElderName(name: String) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(name = name)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
 
+    fun updateElderBirthDate(birthDate: String) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(birthDate = birthDate)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
+
+    fun updateElderGender(gender: Boolean) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(gender = gender)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
+
+    fun updateElderPhoneNumber(phoneNumber: String) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(phoneNumber = phoneNumber)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
+
+    fun updateElderRelationship(relationship: String) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(relationship = relationship)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
+
+    fun updateElderLivingType(livingType: String) {
+        val selectedIndex = _uiState.value.selectedIndex
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList[selectedIndex] = updatedList[selectedIndex].copy(livingType = livingType)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+    }
+
+    fun selectElder(index: Int) {
+        _uiState.value = _uiState.value.copy(
+            selectedIndex = index
+        )
+    }
+
+    fun addElder() {
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList.add(ElderData())
+        _uiState.value = _uiState.value.copy(
+            eldersList = updatedList,
+            selectedIndex = _uiState.value.selectedIndex + 1
+        )
+    }
+
+    fun removeElder(index: Int) {
+        val updatedList = _uiState.value.eldersList.toMutableList()
+        updatedList.removeAt(index)
+        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+
+    }
 
     fun isInputComplete(): Boolean {
-        return elderDataList.all {
+        return uiState.value.eldersList.all {
             it.name.isNotBlank() &&
-                it.birthDate.length == 8 &&
-                it.phoneNumber.length == 11 &&
-                it.relationship.isNotBlank() &&
-                it.livingType.isNotBlank()
+                    it.birthDate.length == 8 &&
+                    it.phoneNumber.length == 11 &&
+                    it.relationship.isNotBlank() &&
+                    it.livingType.isNotBlank()
         }
 
     }
@@ -71,7 +132,7 @@ class LoginElderViewModel @Inject constructor(
     fun createElderHealthDataList() {
 
         elderHealthDataList.apply {
-            repeat(elderDataList.size) { index ->
+            repeat(uiState.value.eldersList.size) { index ->
                 val currentId = getOrNull(index)?.id // 기존 id 보존
 
                 val healthData = ElderHealthData(
@@ -95,8 +156,8 @@ class LoginElderViewModel @Inject constructor(
     fun postElderAndHealth() {
         viewModelScope.launch {
             elderRegisterRepository.registerElderAndHealth(
-                elders = elderDataList.size,
-                elderInfoList = elderDataList,
+                elders = uiState.value.eldersList.size,
+                elderInfoList = uiState.value.eldersList,
                 elderHealthInfo = elderHealthDataList,
             )
                 .onSuccess {
@@ -113,10 +174,10 @@ class LoginElderViewModel @Inject constructor(
         viewModelScope.launch {
             val elderIds = elderIdRepository.getElderIds()
             elderIds.filterIndexed { index, it ->
-                it.values.first() == elderDataList[index].id
+                it.values.first() == uiState.value.eldersList[index].id
             }.forEachIndexed { index, it ->
                 eldersInfoRepository.updateElder(
-                    it.values.first(), elderDataList[index],
+                    it.values.first(), uiState.value.eldersList[index],
                 ).onSuccess {
                     Log.d("httplog", "어르신 재등록(수정) 성공")
                 }.onFailure { exception ->

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -1,12 +1,6 @@
 package com.konkuk.medicarecall.ui.feature.login.senior.viewmodel
 
 import android.util.Log
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.ElderIdRepository
@@ -19,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -113,40 +108,146 @@ class LoginElderViewModel @Inject constructor(
     }
 
     // suggestion: 어르신 등록과 건강정보 등록이 아예 분리된 만큼,
-    // 추후 viewModel 별개로 가지고, 이름과 id값만 내비게이션으로 넘기는 게 나을 듯.
+    // 추후 viewModel 별개로 가지고, 이름과 id값만 내비게이션으로 넘기는 게 나을 것 같습니다.
+
+    // ------------------건강정보 관련 함수------------------
+
+    // 상기한 방법으로 변경할 시 함수 변경 필요
+    fun initElderHealthData() {
+        _elderHealthUiState.update { state ->
+            state.copy(elderHealthList = List(elderUiState.value.eldersList.size) { ElderHealthData() })
+        }
+    }
+
+    fun selectElderInHealth(index: Int) {
+        _elderHealthUiState.update { state ->
+            state.copy(selectedIndex = index)
+        }
+    }
 
 
-    var diseaseInputText = mutableStateListOf<MutableState<String>>()
-    var diseaseList = mutableStateListOf(mutableStateListOf<String>())
+    fun updateDiseasesText(text: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(diseaseInputText = text)
+        }
+    }
 
-    var medMap = mutableStateListOf<SnapshotStateMap<MedicationTimeType, MutableList<String>>>(
+    fun updateMedicationText(text: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(medicationInputText = text)
+        }
+    }
 
-    )
-    var medInputText = mutableStateListOf<MutableState<String>>()
-    var healthIssueList = mutableStateListOf(mutableStateListOf<String>())
+    fun addDisease(disease: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex && disease !in elder.diseaseNames) {
+                        elder.copy(diseaseNames = elder.diseaseNames + disease)
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+
+    }
+
+    fun removeDisease(disease: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) {
+                        elder.copy(notes = elder.diseaseNames.filter { it != disease })
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+    }
 
 
-    val elderHealthDataList = mutableStateListOf<ElderHealthData>()
+    fun addHealthNote(note: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex && note !in elder.notes) {
+                        elder.copy(notes = elder.notes + note)
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+    }
 
-    fun createElderHealthDataList() {
+    fun removeHealthNote(note: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) {
+                        elder.copy(notes = elder.notes.filter { it != note })
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+    }
 
-        elderHealthDataList.apply {
-            repeat(elderUiState.value.eldersList.size) { index ->
-                val currentId = getOrNull(index)?.id // 기존 id 보존
+    fun addMedication(time: MedicationTimeType?, medicine: String) {
+        if (time == null) return
 
-                val healthData = ElderHealthData(
-                    diseaseNames = diseaseList[index],
-                    medicationMap = medMap[index],
-                    notes = healthIssueList[index],
-                    id = currentId,
-                )
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) {
+                        val currentList = elder.medicationMap[time] ?: emptyList()
 
-                if (index < size) {
-                    set(index, healthData) // 항상 덮어쓰기
+                        val updatedMap =
+                            elder.medicationMap + if (medicine !in (elder.medicationMap[time]
+                                    ?: emptyList())
+                            ) (time to (currentList + medicine)) else return
+                        elder.copy(medicationMap = updatedMap)
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+    }
+
+    fun removeMedication(time: MedicationTimeType, medicine: String) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) {
+                        val currentList = elder.medicationMap[time] ?: emptyList()
+                        val updatedList = currentList.filter { it != medicine }
+                        val updatedMap = if (updatedList.isEmpty()) {
+                            elder.medicationMap - time
+                        } else {
+                            elder.medicationMap + (time to updatedList)
+                        }
+                        elder.copy(medicationMap = updatedMap)
+                    } else {
+                        elder
+                    }
+                },
+            )
+        }
+    }
+
+    fun selectMedicationTime(time: MedicationTimeType) {
+        _elderHealthUiState.update { state ->
+            state.copy(
+                selectedMedicationTimes = if (time in state.selectedMedicationTimes) {
+                    state.selectedMedicationTimes - time
                 } else {
-                    add(healthData)
-                }
-            }
+                    state.selectedMedicationTimes + time
+                },
+            )
         }
     }
 
@@ -157,7 +258,7 @@ class LoginElderViewModel @Inject constructor(
             elderRegisterRepository.registerElderAndHealth(
                 elders = elderUiState.value.eldersList.size,
                 elderInfoList = elderUiState.value.eldersList,
-                elderHealthInfo = elderHealthDataList,
+                elderHealthInfo = elderHealthUiState.value.elderHealthList,
             )
                 .onSuccess {
                     Log.d("httplog", "어르신 및 건강정보 전부 등록 성공!")
@@ -195,12 +296,12 @@ class LoginElderViewModel @Inject constructor(
         viewModelScope.launch {
             val elderIds = elderIdRepository.getElderIds()
             elderIds.filterIndexed { index, it ->
-                it.values.first() == elderHealthDataList[index].id
+                it.values.first() == elderHealthUiState.value.elderHealthList[index].id
             }.forEachIndexed { index, it ->
                 runCatching {
                     elderRegisterRepository.postElderHealthInfo(
                         it.values.first(),
-                        elderHealthDataList[index],
+                        elderHealthUiState.value.elderHealthList[index],
                     )
                 }.onSuccess {
                     Log.d("httplog", "어르신 건강정보 재등록(수정) 성공")

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -30,92 +30,91 @@ class LoginElderViewModel @Inject constructor(
 ) : ViewModel() {
     // 어르신 정보 화면
 
-    private val _uiState = MutableStateFlow(LoginElderUiState())
-    val uiState: StateFlow<LoginElderUiState> = _uiState.asStateFlow()
+    private val _elderUiState = MutableStateFlow(LoginElderUiState())
+    val elderUiState: StateFlow<LoginElderUiState> = _elderUiState.asStateFlow()
+
+    private val _elderHealthUiState = MutableStateFlow(LoginElderHealthUiState())
+    val elderHealthUiState: StateFlow<LoginElderHealthUiState> = _elderHealthUiState.asStateFlow()
 
 
     fun updateElderName(name: String) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(name = name)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun updateElderBirthDate(birthDate: String) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(birthDate = birthDate)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun updateElderGender(gender: Boolean) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(gender = gender)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun updateElderPhoneNumber(phoneNumber: String) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(phoneNumber = phoneNumber)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun updateElderRelationship(relationship: String) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(relationship = relationship)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun updateElderLivingType(livingType: String) {
-        val selectedIndex = _uiState.value.selectedIndex
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val selectedIndex = _elderUiState.value.selectedIndex
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList[selectedIndex] = updatedList[selectedIndex].copy(livingType = livingType)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
     }
 
     fun selectElder(index: Int) {
-        _uiState.value = _uiState.value.copy(
-            selectedIndex = index
+        _elderUiState.value = _elderUiState.value.copy(
+            selectedIndex = index,
         )
     }
 
     fun addElder() {
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList.add(ElderData())
-        _uiState.value = _uiState.value.copy(
+        _elderUiState.value = _elderUiState.value.copy(
             eldersList = updatedList,
-            selectedIndex = _uiState.value.selectedIndex + 1
+            selectedIndex = _elderUiState.value.selectedIndex + 1,
         )
     }
 
     fun removeElder(index: Int) {
-        val updatedList = _uiState.value.eldersList.toMutableList()
+        val updatedList = _elderUiState.value.eldersList.toMutableList()
         updatedList.removeAt(index)
-        _uiState.value = _uiState.value.copy(eldersList = updatedList)
+        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
 
     }
 
     fun isInputComplete(): Boolean {
-        return uiState.value.eldersList.all {
+        return elderUiState.value.eldersList.all {
             it.name.isNotBlank() &&
-                    it.birthDate.length == 8 &&
-                    it.phoneNumber.length == 11 &&
-                    it.relationship.isNotBlank() &&
-                    it.livingType.isNotBlank()
+                it.birthDate.length == 8 &&
+                it.phoneNumber.length == 11 &&
+                it.relationship.isNotBlank() &&
+                it.livingType.isNotBlank()
         }
 
     }
 
-    // 건강정보 화면
-    var selectedElder by mutableIntStateOf(0)
-        private set
+    // suggestion: 어르신 등록과 건강정보 등록이 아예 분리된 만큼,
+    // 추후 viewModel 별개로 가지고, 이름과 id값만 내비게이션으로 넘기는 게 나을 듯.
 
-    fun onSelectedElderChanged(new: Int) {
-        selectedElder = new
-    }
 
     var diseaseInputText = mutableStateListOf<MutableState<String>>()
     var diseaseList = mutableStateListOf(mutableStateListOf<String>())
@@ -132,7 +131,7 @@ class LoginElderViewModel @Inject constructor(
     fun createElderHealthDataList() {
 
         elderHealthDataList.apply {
-            repeat(uiState.value.eldersList.size) { index ->
+            repeat(elderUiState.value.eldersList.size) { index ->
                 val currentId = getOrNull(index)?.id // 기존 id 보존
 
                 val healthData = ElderHealthData(
@@ -156,8 +155,8 @@ class LoginElderViewModel @Inject constructor(
     fun postElderAndHealth() {
         viewModelScope.launch {
             elderRegisterRepository.registerElderAndHealth(
-                elders = uiState.value.eldersList.size,
-                elderInfoList = uiState.value.eldersList,
+                elders = elderUiState.value.eldersList.size,
+                elderInfoList = elderUiState.value.eldersList,
                 elderHealthInfo = elderHealthDataList,
             )
                 .onSuccess {
@@ -174,10 +173,10 @@ class LoginElderViewModel @Inject constructor(
         viewModelScope.launch {
             val elderIds = elderIdRepository.getElderIds()
             elderIds.filterIndexed { index, it ->
-                it.values.first() == uiState.value.eldersList[index].id
+                it.values.first() == elderUiState.value.eldersList[index].id
             }.forEachIndexed { index, it ->
                 eldersInfoRepository.updateElder(
-                    it.values.first(), uiState.value.eldersList[index],
+                    it.values.first(), elderUiState.value.eldersList[index],
                 ).onSuccess {
                     Log.d("httplog", "어르신 재등록(수정) 성공")
                 }.onFailure { exception ->

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -177,7 +177,7 @@ class LoginElderViewModel @Inject constructor(
             state.copy(
                 elderHealthList = state.elderHealthList.mapIndexed { index, elder ->
                     if (index == state.selectedIndex) {
-                        elder.copy(notes = elder.diseaseNames.filter { it != disease })
+                        elder.copy(diseaseNames = elder.diseaseNames.filter { it != disease })
                     } else {
                         elder
                     }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/viewmodel/LoginElderViewModel.kt
@@ -33,67 +33,86 @@ class LoginElderViewModel @Inject constructor(
 
 
     fun updateElderName(name: String) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(name = name)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(name = name) else elder
+                },
+            )
+        }
     }
 
     fun updateElderBirthDate(birthDate: String) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(birthDate = birthDate)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(birthDate = birthDate) else elder
+                },
+            )
+        }
     }
 
     fun updateElderGender(gender: Boolean) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(gender = gender)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(gender = gender) else elder
+                },
+            )
+        }
     }
 
     fun updateElderPhoneNumber(phoneNumber: String) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(phoneNumber = phoneNumber)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(phoneNumber = phoneNumber) else elder
+                },
+            )
+        }
     }
 
     fun updateElderRelationship(relationship: String) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(relationship = relationship)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(relationship = relationship) else elder
+                },
+            )
+        }
     }
 
     fun updateElderLivingType(livingType: String) {
-        val selectedIndex = _elderUiState.value.selectedIndex
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList[selectedIndex] = updatedList[selectedIndex].copy(livingType = livingType)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.mapIndexed { index, elder ->
+                    if (index == state.selectedIndex) elder.copy(livingType = livingType) else elder
+                },
+            )
+        }
     }
 
     fun selectElder(index: Int) {
-        _elderUiState.value = _elderUiState.value.copy(
-            selectedIndex = index,
-        )
+        _elderUiState.update { state ->
+            state.copy(selectedIndex = index)
+        }
     }
 
     fun addElder() {
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList.add(ElderData())
-        _elderUiState.value = _elderUiState.value.copy(
-            eldersList = updatedList,
-            selectedIndex = _elderUiState.value.selectedIndex + 1,
-        )
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList + ElderData(),
+                selectedIndex = state.selectedIndex + 1,
+            )
+        }
     }
 
     fun removeElder(index: Int) {
-        val updatedList = _elderUiState.value.eldersList.toMutableList()
-        updatedList.removeAt(index)
-        _elderUiState.value = _elderUiState.value.copy(eldersList = updatedList)
-
+        _elderUiState.update { state ->
+            state.copy(
+                eldersList = state.eldersList.filterIndexed { i, _ -> i != index },
+            )
+        }
     }
 
     fun isInputComplete(): Boolean {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/settings/screen/ElderDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/settings/screen/ElderDetailScreen.kt
@@ -62,7 +62,7 @@ fun PersonalDetailScreen(
     val date = parseDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
     val scrollState = rememberScrollState()
 
-    var isMale by remember { mutableStateOf<Boolean?>(gender) }
+    var isMale by remember { mutableStateOf<Boolean>(gender) }
     var name by remember { mutableStateOf(eldersInfoResponseDto.name) }
     var birth by remember { mutableStateOf(date) }
     var phoneNum by remember { mutableStateOf(eldersInfoResponseDto.phone) }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/settings/screen/MyDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/settings/screen/MyDetailScreen.kt
@@ -44,7 +44,7 @@ fun MyDetailScreen(
     onBack: () -> Unit = {},
     detailMyDataViewModel: DetailMyDataViewModel = hiltViewModel()
 ) {
-    var isMale by remember { mutableStateOf<Boolean?>(myDataInfo.gender == GenderType.MALE) }
+    var isMale by remember { mutableStateOf<Boolean>(myDataInfo.gender == GenderType.MALE) }
     var name by remember { mutableStateOf(myDataInfo.name) }
     var birth by remember { mutableStateOf(myDataInfo.birthDate.replace("-", "")) }
     val scrollState = rememberScrollState()

--- a/app/src/main/java/com/konkuk/medicarecall/ui/model/ElderData.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/model/ElderData.kt
@@ -3,7 +3,7 @@ package com.konkuk.medicarecall.ui.model
 data class ElderData(
     val name: String = "",
     val birthDate: String = "",
-    val gender: Boolean,
+    val gender: Boolean = true,
     val phoneNumber: String = "",
     val relationship: String = "",
     val livingType: String = "",

--- a/app/src/main/java/com/konkuk/medicarecall/ui/model/ElderHealthData.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/model/ElderHealthData.kt
@@ -3,8 +3,8 @@ package com.konkuk.medicarecall.ui.model
 import com.konkuk.medicarecall.ui.type.MedicationTimeType
 
 data class ElderHealthData(
-    val diseaseNames: List<String>,
-    val medicationMap: Map<MedicationTimeType, List<String>>,
-    val notes: List<String>,
-    var id: Int? = null
+    val diseaseNames: List<String> = emptyList(),
+    val medicationMap: Map<MedicationTimeType, List<String>> = emptyMap(),
+    val notes: List<String> = emptyList(),
+    var id: Int? = null,
 )


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #115 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 기존에는 각 텍스트 필드의 값을 리스트로 관리한 뒤, 화면 전환 시 그 리스트를 어르신 데이터 클래스에 담아 전달했지만, 이제는 처음부터 어르신 및 건강정보 객체를 만들어 값을 바로 저장하도록 변경하여, 화면 이동 시 별도의 변환 과정 없이 그대로 전달할 수 있도록 했습니다. 
- UiState를 새로 만들어서 UiState에서 상태를 관리하는 방식으로 변경했습니다.
- 기존에는 컴포넌트로 분리된 컴포저블 함수에 Mutable한 값을 넘겨 상태를 컴포넌트 내부에서 수정했다면, 이제는 이벤트만을 전달해서 모든 상태 변화는 viewmodel에서 처리하도록 수정했습니다.
- 추가로, 상태 관리가 변경되면서 일부 UI의 변경이 있었습니다. 어르신 정보 등록 화면에서 어르신을 여러 명 등록했을 때의 UI가 Chip을 사용한 변경된 디자인으로 바뀌었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 시니어 로그인에 ElderChip 추가 및 ElderInputForm 개편(미리보기 포함).
  - 새 ViewModel과 UI 상태(LoginElderViewModel, LoginElderUiState, LoginElderHealthUiState) 도입으로 다중 보호자/건강정보 입력, 선택, 제거, 콜백 기반 추가/삭제 지원.
- 리팩터링
  - DiseaseNamesItem, MedicationItem을 불변 데이터+콜백 기반의 무상태 컴포저블로 변경.
  - 시니어 정보/건강정보 화면을 상태 수집 기반으로 전환, LazyRow 칩 UI·포커스 제어·검증 흐름 개선.
  - 성별(Boolean) 및 모델 기본값 정리(Nullable 제거, 기본값 제공).
  - 기존 LoginElderViewModel 제거 및 네비게이션/임포트 경로 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->