### PR TITLE
[Fix] 윤년일 경우 없는 날짜 입력 검증 추가 #104

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/util/Extensions.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/util/Extensions.kt
@@ -26,18 +26,33 @@ fun String.isValidDate(): Boolean {
     if (this.length != 8) return false
 
     return try {
-        // "yyyyMMdd" 형식으로 날짜를 파싱
-        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-        val date = LocalDate.parse(this, formatter)
+        val year = this.substring(0, 4).toInt()
+        val month = this.substring(4, 6).toInt()
+        val day = this.substring(6, 8).toInt()
 
-        // 기준 날짜 생성
+        // 월 범위 확인
+        if (month !in 1..12) return false
+
+        // 윤년 판정
+        val isLeapYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+
+        // 각 월의 최대 일수
+        val maxDay = when (month) {
+            2 -> if (isLeapYear) 29 else 28
+            4, 6, 9, 11 -> 30
+            else -> 31
+        }
+
+        // 일 범위 확인
+        if (day !in 1..maxDay) return false
+
+        // 날짜 객체 생성
+        val date = LocalDate.of(year, month, day)
         val minDate = LocalDate.of(1900, 1, 1)
 
-        // 파싱된 날짜가 기준 날짜보다 이전이 아닌지 확인 + 현재 날짜보다 이후 날짜가 아닌지 확인
+        // 날짜 범위 확인
         !date.isBefore(minDate) && !date.isAfter(LocalDate.now())
-
-    } catch (e: DateTimeParseException) {
-        // 날짜 형식이 올바르지 않거나 존재할 수 없는 날짜(예: 20250230)이면 false 반환
+    } catch (e: Exception) {
         false
     }
 }

--- a/app/src/test/java/com/konkuk/medicarecall/ExampleUnitTest.kt
+++ b/app/src/test/java/com/konkuk/medicarecall/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.konkuk.medicarecall
 
+import junit.framework.TestCase.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/app/src/test/java/com/konkuk/medicarecall/ui/common/util/ExtensionsTest.kt
+++ b/app/src/test/java/com/konkuk/medicarecall/ui/common/util/ExtensionsTest.kt
@@ -1,0 +1,77 @@
+package com.konkuk.medicarecall.ui.common.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExtensionsTest {
+
+    @Test
+    fun testLeapYearFebruary29IsValid() {
+        assertTrue("20240229".isValidDate()) // 2024년은 윤년
+        assertTrue("20200229".isValidDate()) // 2020년은 윤년
+        assertTrue("20000229".isValidDate()) // 2000년은 400의 배수로 윤년
+    }
+
+    @Test
+    fun testNonLeapYearFebruary29IsInvalid() {
+        assertFalse("20230229".isValidDate()) // 2023년은 평년
+        assertFalse("20190229".isValidDate()) // 2019년은 평년
+        assertFalse("21000229".isValidDate()) // 2100년은 100의 배수이지만 400의 배수가 아님 (미래 날짜)
+    }
+
+    @Test
+    fun testNonLeapYearFebruary28IsValid() {
+        assertTrue("20230228".isValidDate())
+        assertTrue("20190228".isValidDate())
+        assertTrue("19000228".isValidDate())
+    }
+
+    @Test
+    fun testLeapYearFebruary30IsInvalid() {
+        assertFalse("20240230".isValidDate())
+        assertFalse("20200230".isValidDate())
+    }
+
+    @Test
+    fun testInvalidLengthReturnsInvalid() {
+        assertFalse("2024022".isValidDate()) // 7자리
+        assertFalse("202402299".isValidDate()) // 9자리
+        assertFalse("".isValidDate())
+    }
+
+    @Test
+    fun testDateBefore1900IsInvalid() {
+        assertFalse("18991231".isValidDate())
+        assertFalse("18000101".isValidDate())
+    }
+
+    @Test
+    fun testFutureDateIsInvalid() {
+        assertFalse("20991231".isValidDate())
+        assertFalse("20300101".isValidDate())
+    }
+
+    @Test
+    fun testInvalidDateFormat() {
+        assertFalse("abcdefgh".isValidDate())
+        assertFalse("2024abcd".isValidDate())
+        assertFalse("20241301".isValidDate()) // 13월
+        assertFalse("20240132".isValidDate()) // 32일
+    }
+
+    @Test
+    fun testLastDayOfEachMonth() {
+        assertTrue("20240131".isValidDate()) // 1월 31일
+        assertTrue("20240331".isValidDate()) // 3월 31일
+        assertTrue("20240430".isValidDate()) // 4월 30일
+        assertTrue("20240531".isValidDate()) // 5월 31일
+        assertTrue("20240630".isValidDate()) // 6월 30일
+        assertTrue("20240731".isValidDate()) // 7월 31일
+        assertTrue("20240831".isValidDate()) // 8월 31일
+        assertTrue("20240930".isValidDate()) // 9월 30일
+        assertTrue("20241031".isValidDate()) // 10월 31일
+        assertTrue("20241130".isValidDate()) // 11월 30일
+        assertTrue("20241231".isValidDate()) // 12월 31일
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #104 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 로그인(회원가입) 시 윤년 검증 로직을 추가했습니다.
```kotlin
fun String.isValidDate(): Boolean {
    if (this.length != 8) return false

    return try {
        val year = this.substring(0, 4).toInt()
        val month = this.substring(4, 6).toInt()
        val day = this.substring(6, 8).toInt()

        // 월 범위 확인
        if (month !in 1..12) return false

        // 윤년 판정
        val isLeapYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)

        // 각 월의 최대 일수
        val maxDay = when (month) {
            2 -> if (isLeapYear) 29 else 28
            4, 6, 9, 11 -> 30
            else -> 31
        }

        // 일 범위 확인
        if (day !in 1..maxDay) return false

        // 날짜 객체 생성
        val date = LocalDate.of(year, month, day)
        val minDate = LocalDate.of(1900, 1, 1)

        // 날짜 범위 확인
        !date.isBefore(minDate) && !date.isAfter(LocalDate.now())
    } catch (e: Exception) {
        false
    }
}
```

## 📸 스크린샷 또는 시연 영상 (선택)
<img width="230" height="519" alt="image" src="https://github.com/user-attachments/assets/9283a4d1-363a-445d-aabb-7f9973dbab21" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 날짜 입력 검증 신뢰성을 강화하여 잘못된 형식, 존재하지 않는 날짜, 윤년 예외, 과거/미래 범위 오류를 정확히 식별합니다.
- 버그 수정
  - 일부 유효하지 않은 날짜가 통과되거나 유효한 날짜가 거부될 수 있던 문제를 개선했습니다.
- 테스트
  - 다양한 윤년/월말/형식 오류/범위 검증을 포함한 포괄적 단위 테스트를 추가했습니다.
- 정리
  - 테스트 코드의 불필요한 와일드카드 임포트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->