### PR TITLE
[Fix] 홈화면 한줄요약 카드의 텍스트 색상 수정 #150

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -173,9 +173,9 @@ fun HomeScreenLayout(
     }
 
     val summaryTitleColor =
-        if (hasSummaryData) MediCareCallTheme.colors.white else MediCareCallTheme.colors.g50
+        if (hasSummaryData) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.white
     val summaryBodyColor =
-        if (hasSummaryData) MediCareCallTheme.colors.white else MediCareCallTheme.colors.g50
+        if (hasSummaryData) MediCareCallTheme.colors.g50 else MediCareCallTheme.colors.white
     val summaryText = if (hasSummaryData) homeUiState.balloonMessage else "아직 기록되지 않았어요."
 
     Scaffold(


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #150 

## 📙 작업 설명
- 홈화면내 한줄요약 텍스트의 색상이 맞지 않아 수정하였습니다.

## 📸 스크린샷 또는 시연 영상 (선택)

<table>
  <tr>
    <td align="center"><strong>Before</strong></td>
    <td align="center"><strong>After</strong></td>
  </tr>
  <tr>
    <td>
      <img width="360" alt="Before" src="https://github.com/user-attachments/assets/24bbb2bf-48d4-4522-b8d7-f2c4eef32eec" />
    </td>
    <td>
      <img width="360" alt="After" src="https://github.com/user-attachments/assets/46e33fad-6b80-4022-993c-e77b9c4787c6" />
    </td>
  </tr>
</table>

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 이렇게 간단한(?) 수정도 pr해도 되는지 궁금합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 홈 화면 요약 섹션의 텍스트 색상을 조정했습니다. 데이터가 있을 때는 제목이 짙은 색, 본문이 흰색으로 표시되며, 데이터가 없을 때는 제목이 흰색, 본문이 짙은 색으로 표시됩니다. 요약 데이터 유무에 따라 색상이 자동으로 전환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->