### PR TITLE
[Fix] RefreshToken으로 AccessToken 갱신하지 못하던 문제 수정 #146 

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
@@ -14,7 +14,7 @@ import retrofit2.http.POST
 
 interface AuthService {
     @POST("auth/refresh")
-    suspend fun refreshToken(@Body req: TokenRefreshRequestDto)
+    suspend fun refreshToken(@Header("Refresh-Token") header: String)
         : Response<MemberTokenResponseDto>
 
     @POST("verifications")

--- a/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class AuthAuthenticator @Inject constructor(
     private val dataStoreRepository: DataStoreRepository,
-    private val authService: dagger.Lazy<AuthService> //순환 참조 방지
+    private val authService: dagger.Lazy<AuthService>, //순환 참조 방지
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
@@ -38,14 +38,14 @@ class AuthAuthenticator @Inject constructor(
             }
 
             // 5. RefreshToken이 없으면 갱신 불가, null 반환
-            if (refreshToken == null) {
+            if (refreshToken.isNullOrEmpty()) {
                 // 여기서 로그인 화면으로 보내는 로직을 추가할 수 있습니다. (예: EventBus, SharedFlow 등)
                 return null
             }
 
             // 6. 토큰 갱신 API 호출 (runBlocking 사용)
             val refreshResponse = runBlocking {
-                authService.get().refreshToken(TokenRefreshRequestDto(refreshToken))
+                authService.get().refreshToken(refreshToken)
             }
 
             return if (refreshResponse.isSuccessful && refreshResponse.body() != null) {
@@ -65,7 +65,7 @@ class AuthAuthenticator @Inject constructor(
                 // 9. 토큰 갱신 실패 시 (RefreshToken 만료 등), 저장된 토큰 삭제 후 null 반환
                 Log.e(
                     "AuthAuthenticator",
-                    "Failed to refresh token. Error code: ${refreshResponse.code()}"
+                    "Failed to refresh token. Error code: ${refreshResponse.code()}",
                 )
                 runBlocking { dataStoreRepository.saveRefreshToken("") }
                 // 여기서도 로그인 화면으로 보내는 로직 추가 가능


### PR DESCRIPTION

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #146

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 이제 RefreshToken을 Body가 아닌 Header에 넣어서 보냅니다.
- RefreshToken이 null뿐만 아니라 빈 문자열일때도 정상적으로 작동하도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 자동 재인증(토큰 갱신) 동작의 안정성을 향상해 세션 유지 중 발생하던 간헐적 오류를 줄였습니다.
  - 갱신 토큰이 없을 때의 불필요한 재시도를 방지해 예상치 못한 오류 노출을 줄였습니다.
- 리팩터링
  - 인증 갱신 처리 흐름을 단순화하여 통신 실패 가능성을 낮추고 응답 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->