### PR TITLE
[Fix] AccessToken 만료 시 스플래시 화면에서 멈추는 문제 해결 #168

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
@@ -2,7 +2,6 @@ package com.konkuk.medicarecall.data.api.auth
 
 import com.konkuk.medicarecall.data.dto.request.CertificationCodeRequestDto
 import com.konkuk.medicarecall.data.dto.request.PhoneNumberConfirmRequestDto
-import com.konkuk.medicarecall.data.dto.response.MemberTokenResponseDto
 import com.konkuk.medicarecall.data.dto.response.VerificationResponseDto
 import retrofit2.Response
 import retrofit2.http.Body

--- a/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/api/auth/AuthService.kt
@@ -12,9 +12,6 @@ import retrofit2.http.POST
 /** 인증과 관련된 API 모음 (토큰 갱신, 본인인증, 로그아웃) */
 
 interface AuthService {
-    @POST("auth/refresh")
-    suspend fun refreshToken(@Header("Refresh-Token") header: String): Response<MemberTokenResponseDto>
-
     @POST("verifications")
     suspend fun requestCertificationCode(@Body req: CertificationCodeRequestDto): Response<Unit>
 

--- a/app/src/main/java/com/konkuk/medicarecall/data/api/auth/RefreshService.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/api/auth/RefreshService.kt
@@ -8,5 +8,4 @@ import retrofit2.http.POST
 interface RefreshService {
     @POST("auth/refresh")
     suspend fun refreshToken(@Header("Refresh-Token") header: String): Response<MemberTokenResponseDto>
-
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/api/auth/RefreshService.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/api/auth/RefreshService.kt
@@ -1,0 +1,12 @@
+package com.konkuk.medicarecall.data.api.auth
+
+import com.konkuk.medicarecall.data.dto.response.MemberTokenResponseDto
+import retrofit2.Response
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface RefreshService {
+    @POST("auth/refresh")
+    suspend fun refreshToken(@Header("Refresh-Token") header: String): Response<MemberTokenResponseDto>
+
+}

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/ApiModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/ApiModule.kt
@@ -1,6 +1,7 @@
 package com.konkuk.medicarecall.data.di
 
 import com.konkuk.medicarecall.data.api.auth.AuthService
+import com.konkuk.medicarecall.data.api.auth.RefreshService
 import com.konkuk.medicarecall.data.api.elders.ElderRegisterService
 import com.konkuk.medicarecall.data.api.elders.EldersInfoService
 import com.konkuk.medicarecall.data.api.elders.GlucoseService
@@ -22,11 +23,17 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideRefreshService(@Named("AuthRetrofit") retrofit: Retrofit): RefreshService =
+        retrofit.create(RefreshService::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
@@ -1,7 +1,6 @@
 package com.konkuk.medicarecall.data.di
 
 import com.konkuk.medicarecall.BuildConfig
-import com.konkuk.medicarecall.data.api.auth.AuthService
 import com.konkuk.medicarecall.data.api.auth.RefreshService
 import com.konkuk.medicarecall.data.network.AuthAuthenticator
 import com.konkuk.medicarecall.data.network.AuthInterceptor

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
@@ -34,7 +34,7 @@ object NetworkModule {
     @Singleton
     fun provideAuthAuthenticator(
         dataStoreRepository: DataStoreRepository,
-        refreshService: dagger.Lazy<RefreshService>,
+        refreshService: RefreshService,
     ): AuthAuthenticator {
         return AuthAuthenticator(dataStoreRepository, refreshService)
     }

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/NetworkModule.kt
@@ -1,8 +1,8 @@
 package com.konkuk.medicarecall.data.di
 
-import android.util.Log
 import com.konkuk.medicarecall.BuildConfig
 import com.konkuk.medicarecall.data.api.auth.AuthService
+import com.konkuk.medicarecall.data.api.auth.RefreshService
 import com.konkuk.medicarecall.data.network.AuthAuthenticator
 import com.konkuk.medicarecall.data.network.AuthInterceptor
 import com.konkuk.medicarecall.data.repository.DataStoreRepository
@@ -18,6 +18,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -34,9 +35,9 @@ object NetworkModule {
     @Singleton
     fun provideAuthAuthenticator(
         dataStoreRepository: DataStoreRepository,
-        authService: dagger.Lazy<AuthService>,
+        refreshService: dagger.Lazy<RefreshService>,
     ): AuthAuthenticator {
-        return AuthAuthenticator(dataStoreRepository, authService)
+        return AuthAuthenticator(dataStoreRepository, refreshService)
     }
 
     @Provides
@@ -64,8 +65,28 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    @Named("AuthRetrofit")
+    fun provideAuthRetrofit(loggingInterceptor: HttpLoggingInterceptor): Retrofit {
+        val json = Json {
+            encodeDefaults = true
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val authOkHttpClient = OkHttpClient.Builder()
+            .readTimeout(20, TimeUnit.SECONDS)
+            .addInterceptor(loggingInterceptor)
+            .build()
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .client(authOkHttpClient)
+            .build()
+    }
+
+    @Provides
+    @Singleton
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
-        Log.d("Retrofit", "Base URL: ${BuildConfig.BASE_URL}")
         val json = Json {
             encodeDefaults = true
             ignoreUnknownKeys = true

--- a/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 class AuthAuthenticator @Inject constructor(
     private val dataStoreRepository: DataStoreRepository,
-    private val refreshService: dagger.Lazy<RefreshService>, // 순환 참조 방지
+    private val refreshService: RefreshService,
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
@@ -44,7 +44,7 @@ class AuthAuthenticator @Inject constructor(
 
             // 6. 토큰 갱신 API 호출 (runBlocking 사용)
             val refreshResponse = runBlocking {
-                refreshService.get().refreshToken(refreshToken)
+                refreshService.refreshToken(refreshToken)
             }
 
             return if (refreshResponse.isSuccessful && refreshResponse.body() != null) {

--- a/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/network/AuthAuthenticator.kt
@@ -1,7 +1,7 @@
 package com.konkuk.medicarecall.data.network
 
 import android.util.Log
-import com.konkuk.medicarecall.data.api.auth.AuthService
+import com.konkuk.medicarecall.data.api.auth.RefreshService
 import com.konkuk.medicarecall.data.repository.DataStoreRepository
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 class AuthAuthenticator @Inject constructor(
     private val dataStoreRepository: DataStoreRepository,
-    private val authService: dagger.Lazy<AuthService>, // 순환 참조 방지
+    private val refreshService: dagger.Lazy<RefreshService>, // 순환 참조 방지
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
@@ -44,7 +44,7 @@ class AuthAuthenticator @Inject constructor(
 
             // 6. 토큰 갱신 API 호출 (runBlocking 사용)
             val refreshResponse = runBlocking {
-                authService.get().refreshToken(refreshToken)
+                refreshService.get().refreshToken(refreshToken)
             }
 
             return if (refreshResponse.isSuccessful && refreshResponse.body() != null) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #168 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Authenticator에서 `"auth/refresh"`만 사용하기 위해서 AuthService와 RefreshService를 분리하였습니다.
- AuthRetrofit에는 AuthAuthenticator, AuthInterceptor가 Injection 되지 않아 문제가 생기지 않습니다.
- Deadlock이 발생한 것으로 예상되지만, 구체적인 원인은 더 확인해 봐야 할 것 같습니다.


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 크리티컬한 버그라서 빠르게 리뷰 후 병합해야할 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 인증 토큰 갱신 흐름을 재구성하여 토큰 갱신 요청 처리 방식을 변경했습니다.
  * 인증 실패(401) 시 토큰 갱신 시도가 새로 적용된 방식으로 이루어져 인증 안정성이 향상됩니다.

* **버그 수정**
  * 기존 토큰 갱신 경로 관련 불필요 호출을 제거하고 인증 로직의 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->