### PR TITLE
[Fix] 홈/주간통계 화면 미기록 처리 및 알림 화면 이동 #171

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
@@ -1,16 +1,12 @@
 package com.konkuk.medicarecall.data.dto.response
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class HomeResponseDto(
 
-    @SerialName("elderName")
     val elderName: String = "",
-
-    @SerialName("aiSummary")
-    val aiSummary: String = "",
+    val aiSummary: String? = null,
 
     val mealStatus: MealStatusDto = MealStatusDto(),
     val medicationStatus: MedicationStatusDto = MedicationStatusDto(),
@@ -19,6 +15,7 @@ data class HomeResponseDto(
     val healthStatus: String? = null,
     val mentalStatus: String? = null,
     val bloodSugar: BloodSugarDto? = null,
+    val unreadNotification: Int? = 0,
 ) {
     @Serializable
     data class MealStatusDto(
@@ -29,29 +26,35 @@ data class HomeResponseDto(
 
     @Serializable
     data class MedicationStatusDto(
-        val totalTaken: Int = 0,
-        val totalGoal: Int = 0,
-        val nextMedicationTime: String? = null,
+        val totalTaken: Int? = 0,
+        val totalGoal: Int? = 0,
         val medicationList: List<MedicationDto> = emptyList(),
     )
 
     @Serializable
     data class MedicationDto(
-        val type: String = "",
-        val taken: Int = 0,
-        val goal: Int = 0,
+        val type: String? = null,
+        val taken: Int? = 0,
+        val goal: Int? = 0,
         val nextTime: String? = null,
+        val doseStatusList: List<DoseStatusDto>? = emptyList(),
     )
 
     @Serializable
+    data class DoseStatusDto(
+        val time: String? = null,
+        val taken: Boolean? = null,
+    )
+
+
+    @Serializable
     data class SleepDto(
-        val meanHours: Int = 0,
-        val meanMinutes: Int = 0,
+        val meanHours: Int? = 0,
+        val meanMinutes: Int? = 0,
     )
 
     @Serializable
     data class BloodSugarDto(
-        @SerialName("meanValue")
-        val meanValue: Int = 0,
+        val meanValue: Int? = 0,
     )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
@@ -46,7 +46,6 @@ data class HomeResponseDto(
         val taken: Boolean?,
     )
 
-
     @Serializable
     data class SleepDto(
         val meanHours: Int?,

--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/HomeResponseDto.kt
@@ -6,55 +6,55 @@ import kotlinx.serialization.Serializable
 data class HomeResponseDto(
 
     val elderName: String = "",
-    val aiSummary: String? = null,
+    val aiSummary: String?,
 
-    val mealStatus: MealStatusDto = MealStatusDto(),
-    val medicationStatus: MedicationStatusDto = MedicationStatusDto(),
+    val mealStatus: MealStatusDto,
+    val medicationStatus: MedicationStatusDto,
 
-    val sleep: SleepDto? = null,
-    val healthStatus: String? = null,
-    val mentalStatus: String? = null,
-    val bloodSugar: BloodSugarDto? = null,
-    val unreadNotification: Int? = 0,
+    val sleep: SleepDto?,
+    val healthStatus: String?,
+    val mentalStatus: String?,
+    val bloodSugar: BloodSugarDto?,
+    val unreadNotification: Int?,
 ) {
     @Serializable
     data class MealStatusDto(
-        val breakfast: Boolean? = null,
-        val lunch: Boolean? = null,
-        val dinner: Boolean? = null,
+        val breakfast: Boolean?,
+        val lunch: Boolean?,
+        val dinner: Boolean?,
     )
 
     @Serializable
     data class MedicationStatusDto(
-        val totalTaken: Int? = 0,
-        val totalGoal: Int? = 0,
-        val medicationList: List<MedicationDto> = emptyList(),
+        val totalTaken: Int?,
+        val totalGoal: Int?,
+        val medicationList: List<MedicationDto>?,
     )
 
     @Serializable
     data class MedicationDto(
-        val type: String? = null,
-        val taken: Int? = 0,
-        val goal: Int? = 0,
-        val nextTime: String? = null,
-        val doseStatusList: List<DoseStatusDto>? = emptyList(),
+        val type: String?,
+        val taken: Int?,
+        val goal: Int?,
+        val nextTime: String?,
+        val doseStatusList: List<DoseStatusDto>?,
     )
 
     @Serializable
     data class DoseStatusDto(
-        val time: String? = null,
-        val taken: Boolean? = null,
+        val time: String?,
+        val taken: Boolean?,
     )
 
 
     @Serializable
     data class SleepDto(
-        val meanHours: Int? = 0,
-        val meanMinutes: Int? = 0,
+        val meanHours: Int?,
+        val meanMinutes: Int?,
     )
 
     @Serializable
     data class BloodSugarDto(
-        val meanValue: Int? = 0,
+        val meanValue: Int?,
     )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
@@ -22,19 +22,19 @@ data class StatisticsResponseDto(
     @SerialName("bloodSugar")
     val bloodSugar: BloodSugarDto? = null,
     val subscriptionStartDate: String? = null,
-    val unreadNotification: Int?= null,
+    val unreadNotification: Int? = null,
 )
 
 @Serializable
 data class SummaryStatsDto(
     @SerialName("mealRate")
-    val mealRate: Int?= null,
+    val mealRate: Int? = null,
     @SerialName("medicationRate")
-    val medicationRate: Int?= null,
+    val medicationRate: Int? = null,
     @SerialName("healthSignals")
-    val healthSignals: Int?= null,
+    val healthSignals: Int? = null,
     @SerialName("missedCalls")
-    val missedCalls: Int?= null,
+    val missedCalls: Int? = null,
 )
 
 @Serializable
@@ -50,27 +50,27 @@ data class MealStatsDto(
 @Serializable
 data class MedicationStatDto(
     @SerialName("totalCount")
-    val totalCount: Int?= null,
+    val totalCount: Int? = null,
     @SerialName("takenCount")
-    val takenCount: Int?= null,
+    val takenCount: Int? = null,
 )
 
 @Serializable
 data class AverageSleepDto(
     @SerialName("hours")
-    val hours: Int?= null,
+    val hours: Int? = null,
     @SerialName("minutes")
-    val minutes: Int?= null,
+    val minutes: Int? = null,
 )
 
 @Serializable
 data class PsychSummaryDto(
     @SerialName("good")
-    val good: Int?= null,
+    val good: Int? = null,
     @SerialName("normal")
-    val normal: Int?= null,
+    val normal: Int? = null,
     @SerialName("bad")
-    val bad: Int?= null,
+    val bad: Int? = null,
 )
 
 @Serializable
@@ -84,9 +84,9 @@ data class BloodSugarDto(
 @Serializable
 data class BloodSugarDetailDto(
     @SerialName("normal")
-    val normal: Int?= null,
+    val normal: Int? = null,
     @SerialName("high")
-    val high: Int?= null,
+    val high: Int? = null,
     @SerialName("low")
-    val low: Int?= null,
+    val low: Int? = null,
 )

--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
@@ -21,7 +21,9 @@ data class StatisticsResponseDto(
     val psychSummary: PsychSummaryDto? = null,
     @SerialName("bloodSugar")
     val bloodSugar: BloodSugarDto? = null,
+    @SerialName("subscriptionStartDate")
     val subscriptionStartDate: String? = null,
+    @SerialName("unreadNotification")
     val unreadNotification: Int? = null,
 )
 

--- a/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/dto/response/StatisticsResponseDto.kt
@@ -6,86 +6,87 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StatisticsResponseDto(
     @SerialName("elderName")
-    val elderName: String,
+    val elderName: String = "",
     @SerialName("summaryStats")
-    val summaryStats: SummaryStatsDto,
+    val summaryStats: SummaryStatsDto? = null,
     @SerialName("mealStats")
-    val mealStats: MealStatsDto,
+    val mealStats: MealStatsDto? = null,
     @SerialName("medicationStats")
-    val medicationStats: Map<String, MedicationStatDto>,
+    val medicationStats: Map<String, MedicationStatDto>? = null,
     @SerialName("healthSummary")
     val healthSummary: String? = null,
     @SerialName("averageSleep")
-    val averageSleep: AverageSleepDto,
+    val averageSleep: AverageSleepDto? = null,
     @SerialName("psychSummary")
-    val psychSummary: PsychSummaryDto,
+    val psychSummary: PsychSummaryDto? = null,
     @SerialName("bloodSugar")
-    val bloodSugar: BloodSugarDto,
-    val subscriptionStartDate: String,
+    val bloodSugar: BloodSugarDto? = null,
+    val subscriptionStartDate: String? = null,
+    val unreadNotification: Int?= null,
 )
 
 @Serializable
 data class SummaryStatsDto(
     @SerialName("mealRate")
-    val mealRate: Int,
+    val mealRate: Int?= null,
     @SerialName("medicationRate")
-    val medicationRate: Int,
+    val medicationRate: Int?= null,
     @SerialName("healthSignals")
-    val healthSignals: Int,
+    val healthSignals: Int?= null,
     @SerialName("missedCalls")
-    val missedCalls: Int,
+    val missedCalls: Int?= null,
 )
 
 @Serializable
 data class MealStatsDto(
     @SerialName("breakfast")
-    val breakfast: Int?,
+    val breakfast: Int? = null,
     @SerialName("lunch")
-    val lunch: Int?,
+    val lunch: Int? = null,
     @SerialName("dinner")
-    val dinner: Int?,
+    val dinner: Int? = null,
 )
 
 @Serializable
 data class MedicationStatDto(
     @SerialName("totalCount")
-    val totalCount: Int,
+    val totalCount: Int?= null,
     @SerialName("takenCount")
-    val takenCount: Int?,
+    val takenCount: Int?= null,
 )
 
 @Serializable
 data class AverageSleepDto(
     @SerialName("hours")
-    val hours: Int? = null,
+    val hours: Int?= null,
     @SerialName("minutes")
-    val minutes: Int? = null,
+    val minutes: Int?= null,
 )
 
 @Serializable
 data class PsychSummaryDto(
     @SerialName("good")
-    val good: Int,
+    val good: Int?= null,
     @SerialName("normal")
-    val normal: Int,
+    val normal: Int?= null,
     @SerialName("bad")
-    val bad: Int,
+    val bad: Int?= null,
 )
 
 @Serializable
 data class BloodSugarDto(
     @SerialName("beforeMeal")
-    val beforeMeal: BloodSugarDetailDto,
+    val beforeMeal: BloodSugarDetailDto? = null,
     @SerialName("afterMeal")
-    val afterMeal: BloodSugarDetailDto,
+    val afterMeal: BloodSugarDetailDto? = null,
 )
 
 @Serializable
 data class BloodSugarDetailDto(
     @SerialName("normal")
-    val normal: Int,
+    val normal: Int?= null,
     @SerialName("high")
-    val high: Int,
+    val high: Int?= null,
     @SerialName("low")
-    val low: Int,
+    val low: Int?= null,
 )

--- a/app/src/main/java/com/konkuk/medicarecall/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repository/HomeRepository.kt
@@ -1,9 +1,8 @@
 package com.konkuk.medicarecall.data.repository
 
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeUiState
-import java.time.LocalDate
+import com.konkuk.medicarecall.data.dto.response.HomeResponseDto
 
 interface HomeRepository {
     suspend fun requestImmediateCareCall(elderId: Int, careCallOption: String): Result<Unit>
-    suspend fun getHomeUiState(elderId: Int, date: LocalDate): HomeUiState
+    suspend fun getHomeSummary(elderId: Int): HomeResponseDto
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -3,11 +3,9 @@ package com.konkuk.medicarecall.data.repositoryimpl
 import android.util.Log
 import com.konkuk.medicarecall.data.api.elders.HomeService
 import com.konkuk.medicarecall.data.dto.request.ImmediateCallRequestDto
+import com.konkuk.medicarecall.data.dto.response.HomeResponseDto
 import com.konkuk.medicarecall.data.repository.HomeRepository
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeUiState
 import retrofit2.HttpException
-import java.io.IOException
-import java.time.LocalDate
 import javax.inject.Inject
 
 class HomeRepositoryImpl @Inject constructor(
@@ -35,28 +33,18 @@ class HomeRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getHomeUiState(elderId: Int, date: LocalDate): HomeUiState {
-        return try {
-            Log.d("HomeRepo", "[REQ] elderId=$elderId")
+    override suspend fun getHomeSummary(elderId: Int): HomeResponseDto {
+        // DTO만 반환
+        Log.d("HomeRepo", "[REQ] elderId=$elderId")
+        val res = homeService.getHomeSummary(elderId) // DTO를 받음
 
-            val res = homeService.getHomeSummary(elderId)
+        val meds = res.medicationStatus.medicationList.orEmpty()
+        Log.d(
+            "HomeRepo",
+            "[RES] elderName=${res.elderName}, medsCount=${meds.size}, " +
+                "totalTaken=${res.medicationStatus.totalTaken}, totalGoal=${res.medicationStatus.totalGoal}",
+        )
 
-            val meds = res.medicationStatus.medicationList.orEmpty()
-            Log.d(
-                "HomeRepo",
-                "[RES] elderName=${res.elderName}, medsCount=${meds.size}, " +
-                    "totalTaken=${res.medicationStatus.totalTaken}, totalGoal=${res.medicationStatus.totalGoal}, " +
-                    meds.joinToString(prefix = "items=[", postfix = "]") {
-                        "type=${it.type}, taken=${it.taken}, goal=${it.goal}, next=${it.nextTime}"
-                    },
-            )
-            HomeUiState.from(res)
-        } catch (e: HttpException) {
-            Log.e("HomeRepo", "HTTP error fetching home data: ${e.code()}", e)
-            HomeUiState.Companion.EMPTY
-        } catch (e: IOException) {
-            Log.e("HomeRepo", "Network error fetching home data", e)
-            HomeUiState.Companion.EMPTY
-        }
+        return res
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -3,10 +3,8 @@ package com.konkuk.medicarecall.data.repositoryimpl
 import android.util.Log
 import com.konkuk.medicarecall.data.api.elders.HomeService
 import com.konkuk.medicarecall.data.dto.request.ImmediateCallRequestDto
-import com.konkuk.medicarecall.data.dto.response.HomeResponseDto
 import com.konkuk.medicarecall.data.repository.HomeRepository
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeUiState
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.MedicineUiState
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.LocalDate
@@ -60,27 +58,8 @@ class HomeRepositoryImpl @Inject constructor(
                     },
             )
 
-            HomeUiState(
-                elderName = res.elderName,
-                balloonMessage = res.aiSummary,
-                breakfastEaten = res.mealStatus.breakfast,
-                lunchEaten = res.mealStatus.lunch,
-                dinnerEaten = res.mealStatus.dinner,
+            HomeUiState.from(res)
 
-                medicines = res.medicationStatus.medicationList.orEmpty().map {
-                    MedicineUiState(
-                        medicineName = it.type,
-                        todayTakenCount = it.taken,
-                        todayRequiredCount = it.goal,
-                        nextDoseTime = mapNextTimeToKor(it.nextTime),
-                    )
-                },
-
-                sleep = res.sleep ?: HomeResponseDto.SleepDto(0, 0),
-                healthStatus = res.healthStatus ?: "",
-                mentalStatus = res.mentalStatus ?: "",
-                glucoseLevelAverageToday = res.bloodSugar?.meanValue ?: 0,
-            )
         } catch (e: HttpException) {
             Log.e("HomeRepo", "HTTP error fetching home data: ${e.code()}", e)
             HomeUiState.Companion.EMPTY
@@ -89,11 +68,4 @@ class HomeRepositoryImpl @Inject constructor(
             HomeUiState.Companion.EMPTY
         }
     }
-}
-
-private fun mapNextTimeToKor(nextTime: String?): String = when (nextTime) {
-    "MORNING" -> "아침"
-    "LUNCH" -> "점심"
-    "DINNER" -> "저녁"
-    else -> "-"
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -35,13 +35,6 @@ class HomeRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun mapNextTimeToKor(nextTime: String?): String = when (nextTime) {
-        "MORNING" -> "아침"
-        "LUNCH" -> "점심"
-        "DINNER" -> "저녁"
-        else -> "-"
-    }
-
     override suspend fun getHomeUiState(elderId: Int, date: LocalDate): HomeUiState {
         return try {
             Log.d("HomeRepo", "[REQ] elderId=$elderId")
@@ -57,9 +50,7 @@ class HomeRepositoryImpl @Inject constructor(
                         "type=${it.type}, taken=${it.taken}, goal=${it.goal}, next=${it.nextTime}"
                     },
             )
-
             HomeUiState.from(res)
-
         } catch (e: HttpException) {
             Log.e("HomeRepo", "HTTP error fetching home data: ${e.code()}", e)
             HomeUiState.Companion.EMPTY

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -38,13 +38,13 @@ class HomeRepositoryImpl @Inject constructor(
         Log.d("HomeRepo", "[REQ] elderId=$elderId")
         val res = homeService.getHomeSummary(elderId) // DTO를 받음
 
-        val meds = res.medicationStatus.medicationList.orEmpty()
+        val medicationStatus = res.medicationStatus
+        val meds = medicationStatus?.medicationList.orEmpty()
         Log.d(
             "HomeRepo",
             "[RES] elderName=${res.elderName}, medsCount=${meds.size}, " +
-                "totalTaken=${res.medicationStatus.totalTaken}, totalGoal=${res.medicationStatus.totalGoal}",
+                "totalTaken=${medicationStatus?.totalTaken}, totalGoal=${medicationStatus?.totalGoal}",
         )
-
         return res
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NameBar.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NameBar.kt
@@ -40,7 +40,7 @@ fun NameBar(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Row(
-                Modifier.clickable(
+                modifier = Modifier.clickable(
                     indication = null,
                     interactionSource = null,
                 ) { onDropdownClick() },

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NotificationIconWithBadge.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NotificationIconWithBadge.kt
@@ -32,7 +32,7 @@ fun NotificationIconWithBadge(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = modifier
+        modifier = modifier,
     ) {
         // 1. 알림 아이콘
         Icon(
@@ -43,7 +43,7 @@ fun NotificationIconWithBadge(
                 .size(28.dp)
                 .clickable {
                     onClick()
-                }
+                },
         )
 
         // 2. 알림 개수가 0보다 클 때만 배지를 표시

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NotificationIconWithBadge.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/NotificationIconWithBadge.kt
@@ -32,13 +32,18 @@ fun NotificationIconWithBadge(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = modifier.clickable(onClick = onClick),
+        modifier = modifier
     ) {
         // 1. 알림 아이콘
         Icon(
             painter = painterResource(id = R.drawable.ic_notification),
             contentDescription = "알림",
             tint = Color.Unspecified,
+            modifier = Modifier
+                .size(28.dp)
+                .clickable {
+                    onClick()
+                }
         )
 
         // 2. 알림 개수가 0보다 클 때만 배지를 표시

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/util/WeeklySummaryUtil.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/util/WeeklySummaryUtil.kt
@@ -6,7 +6,6 @@ import com.konkuk.medicarecall.ui.theme.MediCareCallColors
 
 object WeeklySummaryUtil {
     fun getMealIconColor(meal: WeeklySummaryUiState.WeeklyMealUiState, colors: MediCareCallColors): Color {
-        val count = meal.eatenCount ?: 0
         return when {
             meal.eatenCount == meal.totalCount -> colors.positive
             meal.eatenCount in 1 until meal.totalCount -> colors.warning2

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/util/WeeklySummaryUtil.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/util/WeeklySummaryUtil.kt
@@ -1,12 +1,12 @@
 package com.konkuk.medicarecall.ui.common.util
 
 import androidx.compose.ui.graphics.Color
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMealUiState
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMedicineUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState
 import com.konkuk.medicarecall.ui.theme.MediCareCallColors
 
 object WeeklySummaryUtil {
-    fun getMealIconColor(meal: WeeklyMealUiState, colors: MediCareCallColors): Color {
+    fun getMealIconColor(meal: WeeklySummaryUiState.WeeklyMealUiState, colors: MediCareCallColors): Color {
+        val count = meal.eatenCount ?: 0
         return when {
             meal.eatenCount == meal.totalCount -> colors.positive
             meal.eatenCount in 1 until meal.totalCount -> colors.warning2
@@ -15,7 +15,7 @@ object WeeklySummaryUtil {
         }
     }
 
-    fun getMedicineIconColor(medicine: WeeklyMedicineUiState, colors: MediCareCallColors): Color {
+    fun getMedicineIconColor(medicine: WeeklySummaryUiState.WeeklyMedicineUiState, colors: MediCareCallColors): Color {
         return when {
             medicine.takenCount == medicine.totalCount -> colors.positive
             medicine.takenCount in 1 until medicine.totalCount -> colors.warning2

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeGlucoseLevelContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeGlucoseLevelContainer.kt
@@ -28,7 +28,7 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 @Composable
 fun HomeGlucoseLevelContainer(
     modifier: Modifier = Modifier,
-    glucoseLevelAverageToday: Int,
+    glucoseLevelAverageToday: Int?,
     onClick: () -> Unit,
 ) {
     Card(
@@ -77,7 +77,7 @@ fun HomeGlucoseLevelContainer(
             Column(
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                val isRecorded = glucoseLevelAverageToday > 0
+                val isRecorded = (glucoseLevelAverageToday ?: 0) > 0
                 val glucoseText = if (isRecorded) "$glucoseLevelAverageToday" else "--"
                 val textColor = if (isRecorded) {
                     MediCareCallTheme.colors.gray8

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
@@ -167,9 +167,7 @@ fun HomeMedicineContainer(
                         style = MediCareCallTheme.typography.R_14,
                         color = MediCareCallTheme.colors.gray5,
                     )
-
                 }
-
 
                 if (idx < medicines.lastIndex) {
                     Spacer(modifier = Modifier.height(22.dp))

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
@@ -74,8 +74,8 @@ fun HomeMedicineContainer(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 // 전체 복약 상태
-                val totalTaken = medicines.sumOf { it.todayTakenCount ?: 0}
-                val totalRequired = medicines.sumOf { it.todayRequiredCount ?: 0}
+                val totalTaken = medicines.sumOf { it.todayTakenCount ?: 0 }
+                val totalRequired = medicines.sumOf { it.todayRequiredCount ?: 0 }
                 Row(
                     modifier = Modifier,
                     verticalAlignment = Alignment.Bottom,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeMedicineContainer.kt
@@ -33,35 +33,7 @@ fun HomeMedicineContainer(
     modifier: Modifier = Modifier,
     medicines: List<MedicineUiState>,
     onClick: () -> Unit,
-) { // TODO: 복약 상태 아이콘 리스트
-//    // 이상치 방어
-//    val safeRequired = remember(todayRequiredCount) { todayRequiredCount.coerceAtLeast(0) }
-//
-//
-//    val renderList = remember(doseStatusList, safeRequired) {
-//        if (safeRequired == 0) {
-//            emptyList()
-//        } else {
-//            val normalized = doseStatusList.map {
-//                when (it.doseStatus) {
-//                    DoseStatus.TAKEN -> it.copy(doseStatus = DoseStatus.TAKEN)
-//                    DoseStatus.SKIPPED -> it.copy(doseStatus = DoseStatus.SKIPPED)
-//                    DoseStatus.NOT_RECORDED -> it.copy(doseStatus = DoseStatus.NOT_RECORDED)
-//                }
-//            }
-//            when {
-//                normalized.isEmpty() -> List(safeRequired) {
-//                    DoseStatusItem(time = "", doseStatus = DoseStatus.NOT_RECORDED)
-//                }
-//
-//                normalized.size < safeRequired -> normalized + List(safeRequired - normalized.size) {
-//                    DoseStatusItem(time = "", doseStatus = DoseStatus.NOT_RECORDED)
-//                }
-//
-//                else -> normalized.take(safeRequired)
-//            }
-//        }
-//    }
+) {
     Card(
         modifier = modifier
             .clickable { onClick() }
@@ -102,8 +74,8 @@ fun HomeMedicineContainer(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 // 전체 복약 상태
-                val totalTaken = medicines.sumOf { it.todayTakenCount }
-                val totalRequired = medicines.sumOf { it.todayRequiredCount }
+                val totalTaken = medicines.sumOf { it.todayTakenCount ?: 0}
+                val totalRequired = medicines.sumOf { it.todayRequiredCount ?: 0}
                 Row(
                     modifier = Modifier,
                     verticalAlignment = Alignment.Bottom,
@@ -177,7 +149,7 @@ fun HomeMedicineContainer(
 //                            }
 
                             Text(
-                                text = "${medicine.todayTakenCount}/${medicine.todayRequiredCount}회 복용",
+                                text = "${medicine.todayTakenCount ?: 0}/${medicine.todayRequiredCount ?: 0}회 복용",
                                 style = MediCareCallTheme.typography.R_14,
                                 color = MediCareCallTheme.colors.gray5,
                             )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeStateHealthContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeStateHealthContainer.kt
@@ -29,7 +29,7 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 @Composable
 fun HomeStateHealthContainer(
     modifier: Modifier = Modifier,
-    healthStatus: String,
+    healthStatus: String?,
     onClick: () -> Unit,
 ) {
     Card(
@@ -76,14 +76,14 @@ fun HomeStateHealthContainer(
                     modifier = Modifier,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    val textColor = if (healthStatus.isBlank()) {
+                    val textColor = if (healthStatus.isNullOrBlank()) {
                         MediCareCallTheme.colors.gray4
                     } else {
                         MediCareCallTheme.colors.gray8
                     }
 
                     Text(
-                        text = healthStatus.ifBlank { "미기록" },
+                        text = if (healthStatus.isNullOrBlank()) "미기록" else healthStatus,
                         style = MediCareCallTheme.typography.SB_22,
                         color = textColor,
                     )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeStateMentalContainer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/component/HomeStateMentalContainer.kt
@@ -29,7 +29,7 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 @Composable
 fun HomeStateMentalContainer(
     modifier: Modifier = Modifier,
-    mentalStatus: String,
+    mentalStatus: String?,
     onClick: () -> Unit,
 ) {
     Card(
@@ -76,14 +76,14 @@ fun HomeStateMentalContainer(
                     modifier = Modifier,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    val textColor = if (mentalStatus.isBlank()) {
+                    val textColor = if (mentalStatus.isNullOrBlank()) {
                         MediCareCallTheme.colors.gray4
                     } else {
                         MediCareCallTheme.colors.gray8
                     }
 
                     Text(
-                        text = mentalStatus.ifBlank { "미기록" },
+                        text = if (mentalStatus.isNullOrBlank()) "미기록" else mentalStatus,
                         style = MediCareCallTheme.typography.SB_22,
                         color = textColor,
                     )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
@@ -18,6 +18,7 @@ fun NavGraphBuilder.homeNavGraph(
     navigateToStateHealthDetailScreen: () -> Unit,
     navigateToStateMentalDetailScreen: () -> Unit,
     navigateToGlucoseDetailScreen: () -> Unit,
+    navigateToAlarmScreen: () -> Unit,
 ) {
     composable<MainTabRoute.Home> { backStackEntry ->
         HomeScreen(
@@ -28,6 +29,7 @@ fun NavGraphBuilder.homeNavGraph(
             navigateToStateMentalDetailScreen = navigateToStateMentalDetailScreen,
             navigateToGlucoseDetailScreen = navigateToGlucoseDetailScreen,
             mainBackStackEntry = backStackEntry,
+            navigateToAlarm = navigateToAlarmScreen,
         )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -378,7 +378,7 @@ fun HomeScreenLayout(
                                 HomeMedicineContainer(
                                     medicines = homeUiState.medicines,
                                     onClick = navigateToMedicineDetailScreen,
-                                    )
+                                )
                                 Spacer(Modifier.height(12.dp))
                                 val sleepData = homeUiState.sleep
                                 HomeSleepContainer(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -276,10 +276,9 @@ fun HomeScreenLayout(
                 NameBar(
                     name = selectedElderName,
                     modifier = Modifier.statusBarsPadding(),
-                    navigateToAlarm = navigateToAlarm,
                     onDropdownClick = onDropdownClick,
-                    // TODO: 실제 알림 개수 데이터 연동 필요
-                    notificationCount = 4,
+                    notificationCount = homeUiState.unreadNotification,
+                    navigateToAlarm = navigateToAlarm,
                 )
                 val scope = rememberCoroutineScope()
 
@@ -379,13 +378,13 @@ fun HomeScreenLayout(
                                 HomeMedicineContainer(
                                     medicines = homeUiState.medicines,
                                     onClick = navigateToMedicineDetailScreen,
-                                )
+                                    )
                                 Spacer(Modifier.height(12.dp))
                                 val sleepData = homeUiState.sleep
                                 HomeSleepContainer(
-                                    totalSleepHours = sleepData.meanHours,
-                                    totalSleepMinutes = sleepData.meanMinutes,
-                                    isRecorded = sleepData.meanHours > 0 || sleepData.meanMinutes > 0,
+                                    totalSleepHours = sleepData.meanHours ?: 0,
+                                    totalSleepMinutes = sleepData.meanMinutes ?: 0,
+                                    isRecorded = (sleepData.meanHours ?: 0) > 0 || (sleepData.meanMinutes ?: 0) > 0,
                                     onClick = navigateToSleepDetailScreen,
                                 )
                                 Spacer(Modifier.height(12.dp))

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -80,6 +80,7 @@ fun HomeScreen(
     navigateToStateMentalDetailScreen: () -> Unit,
     navigateToGlucoseDetailScreen: () -> Unit,
     mainBackStackEntry: NavBackStackEntry,
+    navigateToAlarm: () -> Unit,
 ) {
     val homeUiState by homeViewModel.homeUiState.collectAsStateWithLifecycle()
     val elderInfoList by homeViewModel.elderInfoList.collectAsStateWithLifecycle()
@@ -122,6 +123,8 @@ fun HomeScreen(
         navigateToStateHealthDetailScreen = navigateToStateHealthDetailScreen,
         navigateToStateMentalDetailScreen = navigateToStateMentalDetailScreen,
         navigateToGlucoseDetailScreen = navigateToGlucoseDetailScreen,
+        navigateToAlarm = navigateToAlarm,
+
         snackbarHostState = snackbarHostState,
         isLoading = homeUiState.isLoading,
         onFabClick = {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -277,7 +277,7 @@ fun HomeScreenLayout(
                     name = selectedElderName,
                     modifier = Modifier.statusBarsPadding(),
                     onDropdownClick = onDropdownClick,
-                    notificationCount = homeUiState.unreadNotification,
+                    notificationCount = homeUiState.unreadNotification ?: 0,
                     navigateToAlarm = navigateToAlarm,
                 )
                 val scope = rememberCoroutineScope()
@@ -382,9 +382,9 @@ fun HomeScreenLayout(
                                 Spacer(Modifier.height(12.dp))
                                 val sleepData = homeUiState.sleep
                                 HomeSleepContainer(
-                                    totalSleepHours = sleepData.meanHours ?: 0,
-                                    totalSleepMinutes = sleepData.meanMinutes ?: 0,
-                                    isRecorded = (sleepData.meanHours ?: 0) > 0 || (sleepData.meanMinutes ?: 0) > 0,
+                                    totalSleepHours = sleepData?.meanHours ?: 0,
+                                    totalSleepMinutes = sleepData?.meanMinutes ?: 0,
+                                    isRecorded = (sleepData?.meanHours ?: 0) > 0 || (sleepData?.meanMinutes ?: 0) > 0,
                                     onClick = navigateToSleepDetailScreen,
                                 )
                                 Spacer(Modifier.height(12.dp))

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
@@ -11,11 +11,14 @@ data class HomeUiState(
     val breakfastEaten: Boolean? = null,
     val lunchEaten: Boolean? = null,
     val dinnerEaten: Boolean? = null,
+    val totalTaken: Int? = null,
+    val totalGoal: Int? = null,
     val medicines: List<MedicineUiState> = emptyList(),
-    val sleep: HomeResponseDto.SleepDto = HomeResponseDto.SleepDto(0, 0),
-    val healthStatus: String = "",
-    val mentalStatus: String = "",
-    val glucoseLevelAverageToday: Int = 0,
+    val sleep: HomeResponseDto.SleepDto? = null,
+    val healthStatus: String? = null,
+    val mentalStatus: String? = null,
+    val glucoseLevelAverageToday: Int? = null,
+    val unreadNotification: Int? = null,
 ) {
     companion object {
         val EMPTY = HomeUiState()
@@ -24,7 +27,7 @@ data class HomeUiState(
             elderName = dto.elderName,
             balloonMessage = dto.aiSummary.orEmpty(),
 
-            // 기록 존재 여부(세 끼 중 하나라도 null 아님)
+            // 기록 존재 여부(세 끼 중 하나라도 null 아니면 true)
             isRecorded = listOf(
                 dto.mealStatus.breakfast,
                 dto.mealStatus.lunch,
@@ -42,33 +45,36 @@ data class HomeUiState(
             lunchEaten = dto.mealStatus.lunch,
             dinnerEaten = dto.mealStatus.dinner,
 
+            totalTaken = dto.medicationStatus.totalTaken,
+            totalGoal = dto.medicationStatus.totalGoal,
+
             medicines = dto.medicationStatus.medicationList
                 .orEmpty()
                 .map {
                     MedicineUiState(
-                        medicineName = it.type,
+                        medicineName = it.type.orEmpty(),
                         todayTakenCount = it.taken,
                         todayRequiredCount = it.goal,
                         nextDoseTime = when (it.nextTime) {
                             "MORNING" -> "아침"
                             "LUNCH" -> "점심"
                             "DINNER" -> "저녁"
-                            null, "" -> "-"
                             else -> it.nextTime
                         },
                     )
                 },
-            sleep = dto.sleep ?: HomeResponseDto.SleepDto(0, 0),
-            healthStatus = dto.healthStatus ?: "",
-            mentalStatus = dto.mentalStatus ?: "",
-            glucoseLevelAverageToday = dto.bloodSugar?.meanValue ?: 0,
+            sleep = dto.sleep,
+            healthStatus = dto.healthStatus,
+            mentalStatus = dto.mentalStatus,
+            glucoseLevelAverageToday = dto.bloodSugar?.meanValue,
+            unreadNotification = dto.unreadNotification,
         )
     }
 }
 
 data class MedicineUiState(
     val medicineName: String,
-    val todayTakenCount: Int,
-    val todayRequiredCount: Int,
+    val todayTakenCount: Int?,
+    val todayRequiredCount: Int?,
     val nextDoseTime: String?,
 )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
 import retrofit2.HttpException
 import java.time.LocalDate
 import javax.inject.Inject
@@ -43,7 +42,7 @@ class HomeViewModel @Inject constructor(
         _homeUiState.value = _homeUiState.value.copy(elderName = newName)
 
         _homeUiState.update { it.copy(isLoading = false) }
-        softRefreshCurrentElder()
+//        softRefreshCurrentElder()
     }
 
     var isLoading by mutableStateOf(true)
@@ -145,10 +144,13 @@ class HomeViewModel @Inject constructor(
             _homeUiState.update { it.copy(isLoading = false) }
             val today = LocalDate.now()
             try {
-                // ① 요약 API 호출
-                val uiFromServer = homeRepository.getHomeUiState(elderId, today)
+                // ① 요약 API 호출 (DTO를 받음)
+                val dto = homeRepository.getHomeSummary(elderId)
 
-                // ② 설정/건강정보 최신화(중요)
+                // ② DTO를 UiState로 변환 (ViewModel이 직접 함)
+                val uiFromServer = HomeUiState.from(dto)
+
+                // ③ 설정/건강정보 최신화(중요)
                 eldersHealthInfoRepository.refresh()
                 val healthInfo = eldersHealthInfoRepository.getEldersHealthInfo()
                     .getOrNull()
@@ -173,6 +175,7 @@ class HomeViewModel @Inject constructor(
                             todayTakenCount = 0, // 요약이 없으니 기본 0
                             todayRequiredCount = group.size, // 같은 약이 여러 복용시간이면 개수 = 요구횟수
                             nextDoseTime = "-", // 시간표시 필요없으면 "-" 유지
+                            doseStatusList = emptyList(),
                         )
                     }
                     ?: emptyList()
@@ -286,56 +289,58 @@ class HomeViewModel @Inject constructor(
             list.associate { it.name to it.id }
         }
 
-    private fun softRefreshCurrentElder(timeoutMs: Long = 1200L) {
-        val id = selectedElderId.value ?: return
-        viewModelScope.launch {
-            val keepName = _homeUiState.value.elderName
-
-            runCatching {
-                withTimeout(timeoutMs) {
-                    val today = java.time.LocalDate.now()
-                    val uiFromServer = homeRepository.getHomeUiState(id, today)
-
-                    val healthInfo = runCatching {
-                        eldersHealthInfoRepository.refresh()
-                        eldersHealthInfoRepository.getEldersHealthInfo().getOrNull()
-                            ?.firstOrNull { it.elderId == id }
-                    }.getOrNull()
-
-                    val correctMedicationOrder = healthInfo?.medications
-                        ?.flatMap { it.value }
-                        ?.distinct().orEmpty()
-
-                    val mergedMedicines = if (uiFromServer.medicines.isNotEmpty()) {
-                        uiFromServer.medicines
-                    } else {
-                        healthInfo?.medications
-                            ?.flatMap { (time, meds) -> meds.map { it to time } }
-                            ?.groupBy { it.first }
-                            ?.map { (name, group) ->
-                                MedicineUiState(
-                                    medicineName = name,
-                                    todayTakenCount = 0,
-                                    todayRequiredCount = group.size,
-                                    nextDoseTime = "-",
-                                )
-                            }.orEmpty()
-                    }.sortedBy { med ->
-                        correctMedicationOrder.indexOf(med.medicineName)
-                            .let { if (it == -1) Int.MAX_VALUE else it }
-                    }
-
-                    _homeUiState.value = uiFromServer.copy(
-                        elderName = keepName,
-                        medicines = mergedMedicines,
-                        isLoading = false,
-                    )
-                }
-            }.onFailure {
-                _homeUiState.update { it.copy(isLoading = false) }
-            }
-        }
-    }
+//    private fun softRefreshCurrentElder(timeoutMs: Long = 1200L) {
+//        val id = selectedElderId.value ?: return
+//        viewModelScope.launch {
+//            val keepName = _homeUiState.value.elderName
+//
+//            runCatching {
+//                withTimeout(timeoutMs) {
+//                    val today = LocalDate.now()
+//                    val dto = homeRepository.getHomeSummary(id, today)
+//                    val uiFromServer = HomeUiState.from(dto)
+//
+//                    val healthInfo = runCatching {
+//                        eldersHealthInfoRepository.refresh()
+//                        eldersHealthInfoRepository.getEldersHealthInfo().getOrNull()
+//                            ?.firstOrNull { it.elderId == id }
+//                    }.getOrNull()
+//
+//                    val correctMedicationOrder = healthInfo?.medications
+//                        ?.flatMap { it.value }
+//                        ?.distinct().orEmpty()
+//
+//                    val mergedMedicines = if (uiFromServer.medicines.isNotEmpty()) {
+//                        uiFromServer.medicines
+//                    } else {
+//                        healthInfo?.medications
+//                            ?.flatMap { (time, meds) -> meds.map { it to time } }
+//                            ?.groupBy { it.first }
+//                            ?.map { (name, group) ->
+//                                MedicineUiState(
+//                                    medicineName = name,
+//                                    todayTakenCount = 0,
+//                                    todayRequiredCount = group.size,
+//                                    nextDoseTime = "-",
+//                                    doseStatusList = emptyList(),
+//                                )
+//                            }.orEmpty()
+//                    }.sortedBy { med ->
+//                        correctMedicationOrder.indexOf(med.medicineName)
+//                            .let { if (it == -1) Int.MAX_VALUE else it }
+//                    }
+//
+//                    _homeUiState.value = uiFromServer.copy(
+//                        elderName = keepName,
+//                        medicines = mergedMedicines,
+//                        isLoading = false,
+//                    )
+//                }
+//            }.onFailure {
+//                _homeUiState.update { it.copy(isLoading = false) }
+//            }
+//        }
+//    }
 
     // StateFlow 변환용 확장 함수
     fun <T, R> StateFlow<T>.mapState(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
-import java.time.LocalDate
 import javax.inject.Inject
 
 data class ElderInfo(val id: Int, val name: String, val phone: String?)
@@ -142,7 +141,7 @@ class HomeViewModel @Inject constructor(
     private fun fetchHomeSummaryForToday(elderId: Int) {
         viewModelScope.launch {
             _homeUiState.update { it.copy(isLoading = false) }
-            val today = LocalDate.now()
+            //val today = LocalDate.now()
             try {
                 // ① 요약 API 호출 (DTO를 받음)
                 val dto = homeRepository.getHomeSummary(elderId)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
-import java.time.LocalDate
 import javax.inject.Inject
 
 data class ElderInfo(val id: Int, val name: String, val phone: String?)
@@ -142,7 +141,7 @@ class HomeViewModel @Inject constructor(
     private fun fetchHomeSummaryForToday(elderId: Int) {
         viewModelScope.launch {
             _homeUiState.update { it.copy(isLoading = false) }
-            val today = LocalDate.now()
+            // val today = LocalDate.now()
             try {
                 // ① 요약 API 호출 (DTO를 받음)
                 val dto = homeRepository.getHomeSummary(elderId)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -41,7 +41,7 @@ class HomeViewModel @Inject constructor(
         _homeUiState.value = _homeUiState.value.copy(elderName = newName)
 
         _homeUiState.update { it.copy(isLoading = false) }
-    //  softRefreshCurrentElder()
+        //  softRefreshCurrentElder()
     }
 
     var isLoading by mutableStateOf(true)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/screen/StatisticsScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/screen/StatisticsScreen.kt
@@ -39,11 +39,8 @@ import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.statistics.component.WeekendBar
 import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.StatisticsUiState
 import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.StatisticsViewModel
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyGlucoseUiState
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMealUiState
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMedicineUiState
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMentalUiState
 import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState.WeeklyMedicineUiState
 import com.konkuk.medicarecall.ui.feature.statistics.weeklycard.WeeklyGlucoseCard
 import com.konkuk.medicarecall.ui.feature.statistics.weeklycard.WeeklyHealthCard
 import com.konkuk.medicarecall.ui.feature.statistics.weeklycard.WeeklyMealCard
@@ -159,9 +156,9 @@ fun StatisticsScreenLayout(
         NameBar(
             name = currentElderName,
             modifier = Modifier.statusBarsPadding(),
-            navigateToAlarm = navigateToAlarm,
             onDropdownClick = { dropdownOpened.value = !dropdownOpened.value },
-            notificationCount = 4, //  TODO: 실제 알림 개수 데이터 연동 필요
+            notificationCount = uiState.summary?.unreadNotification ?: 0,
+            navigateToAlarm = navigateToAlarm,
         )
 
         when {
@@ -282,9 +279,9 @@ fun PreviewStatisticsScreenRecorded() {
         weeklyHealthIssueCount = 3,
         weeklyUnansweredCount = 8,
         weeklyMeals = listOf(
-            WeeklyMealUiState("아침", 7, 7),
-            WeeklyMealUiState("점심", 5, 7),
-            WeeklyMealUiState("저녁", 1, 7),
+            WeeklySummaryUiState.WeeklyMealUiState("아침", 7, 7),
+            WeeklySummaryUiState.WeeklyMealUiState("점심", 5, 7),
+            WeeklySummaryUiState.WeeklyMealUiState("저녁", 1, 7),
         ),
         weeklyMedicines = listOf(
             WeeklyMedicineUiState("혈압약", 0, 14),
@@ -301,8 +298,8 @@ fun PreviewStatisticsScreenRecorded() {
         weeklyHealthNote = "아침·점심 복약과 식사는 문제 없으나, 저녁 약 복용이 늦어질 우려가 있어요. 전반적으로 양호하나 피곤과 후흡곤란을 호소하셨으므로 휴식과 보호자 확인이 필요해요.",
         weeklySleepHours = 7,
         weeklySleepMinutes = 12,
-        weeklyMental = WeeklyMentalUiState(good = 4, normal = 4, bad = 1),
-        weeklyGlucose = WeeklyGlucoseUiState(
+        weeklyMental = WeeklySummaryUiState.WeeklyMentalUiState(good = 4, normal = 4, bad = 1),
+        weeklyGlucose = WeeklySummaryUiState.WeeklyGlucoseUiState(
             beforeMealNormal = 5,
             beforeMealHigh = 2,
             beforeMealLow = 1,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/screen/StatisticsScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/screen/StatisticsScreen.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.konkuk.medicarecall.ui.common.component.NameBar
 import com.konkuk.medicarecall.ui.common.component.NameDropdown
+import com.konkuk.medicarecall.ui.feature.alarm.navigation.navigateToAlarm
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.statistics.component.WeekendBar
 import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.StatisticsUiState
@@ -58,7 +59,7 @@ import java.time.LocalDate
 fun StatisticsScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController,
-//    navigateToAlarm: () -> Unit = {},
+    navigateToAlarm: () -> Unit = {},
     homeViewModel: HomeViewModel,
     statisticsViewModel: StatisticsViewModel = hiltViewModel(),
 ) {
@@ -130,6 +131,7 @@ fun StatisticsScreen(
         onNextWeek = { statisticsViewModel.showNextWeek() },
         onDropdownItemSelected = { name -> homeViewModel.selectElder(name) },
         currentElderName = currentElderName,
+        navigateToAlarm = { navController.navigateToAlarm() },
     )
 }
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
@@ -3,8 +3,6 @@ package com.konkuk.medicarecall.ui.feature.statistics.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.konkuk.medicarecall.data.dto.response.MedicationStatDto
-import com.konkuk.medicarecall.data.dto.response.StatisticsResponseDto
 import com.konkuk.medicarecall.data.repository.EldersHealthInfoRepository
 import com.konkuk.medicarecall.data.repository.StatisticsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -163,8 +161,8 @@ class StatisticsViewModel @Inject constructor(
                 }
 
                 Log.d("STATISTICS_DEBUG", "onSuccess: DTO 수신 완료\n$dto")
-                val summary = dto.toWeeklySummaryUiState(order)
-                Log.d("STATISTICS_DEBUG", "onSuccess: UI State로 변환 완료\n$summary")
+                val summary = WeeklySummaryUiState.from(dto, order)
+                Log.d("STATISTICS_DEBUG", "onSuccess: UI State 변환 완료\n$summary")
 
                 _uiState.value = StatisticsUiState(
                     isLoading = false,
@@ -192,65 +190,6 @@ class StatisticsViewModel @Inject constructor(
         }
     }
 
-    // toWeeklySummaryUiState 함수는 변경 없음 (생략)
-    private fun StatisticsResponseDto.toWeeklySummaryUiState(correctOrder: List<String>): WeeklySummaryUiState {
-        // ... (이전 코드와 동일)
-        val indexOf: (String) -> Int = { key ->
-            val idx = correctOrder.indexOf(key)
-            if (idx == -1) Int.MAX_VALUE else idx
-        }
-
-        val orderedMedicines = medicationStats.entries
-            .sortedWith(
-                compareBy<Map.Entry<String, MedicationStatDto>>(
-                    { indexOf(it.key) },
-                    { it.key },
-                ),
-            )
-            .map { (name, stats) ->
-                WeeklyMedicineUiState(
-                    medicineName = name,
-                    takenCount = stats.takenCount,
-                    totalCount = stats.totalCount,
-                )
-            }
-
-        val sleepH = averageSleep.hours
-        val sleepM = averageSleep.minutes
-
-        // UI 색상 문제 대응 TODO: 서버에서 null로 변경시 해당 로직 제거
-        val noteText = healthSummary.takeIf { it != EMPTY_HEALTH_MESSAGE && it != null } ?: ""
-
-        return WeeklySummaryUiState(
-            elderName = elderName,
-            weeklyMealRate = summaryStats.mealRate,
-            weeklyMedicineRate = summaryStats.medicationRate,
-            weeklyHealthIssueCount = summaryStats.healthSignals,
-            weeklyUnansweredCount = summaryStats.missedCalls,
-            weeklyMeals = listOf(
-                WeeklyMealUiState("아침", mealStats.breakfast, 7),
-                WeeklyMealUiState("점심", mealStats.lunch, 7),
-                WeeklyMealUiState("저녁", mealStats.dinner, 7),
-            ),
-            weeklyMedicines = orderedMedicines,
-            weeklyHealthNote = noteText,
-            weeklySleepHours = sleepH,
-            weeklySleepMinutes = sleepM,
-            weeklyMental = WeeklyMentalUiState(
-                good = psychSummary.good,
-                normal = psychSummary.normal,
-                bad = psychSummary.bad,
-            ),
-            weeklyGlucose = WeeklyGlucoseUiState(
-                beforeMealNormal = bloodSugar.beforeMeal.normal,
-                beforeMealHigh = bloodSugar.beforeMeal.high,
-                beforeMealLow = bloodSugar.beforeMeal.low,
-                afterMealNormal = bloodSugar.afterMeal.normal,
-                afterMealHigh = bloodSugar.afterMeal.high,
-                afterMealLow = bloodSugar.afterMeal.low,
-            ),
-        )
-    }
     companion object {
         private const val EMPTY_HEALTH_MESSAGE = "아직 충분한 기록이 쌓이지 않았어요."
     }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
@@ -189,8 +189,4 @@ class StatisticsViewModel @Inject constructor(
             }
         }
     }
-
-    companion object {
-        private const val EMPTY_HEALTH_MESSAGE = "아직 충분한 기록이 쌓이지 않았어요."
-    }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/WeeklySummaryUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/WeeklySummaryUiState.kt
@@ -1,5 +1,7 @@
 package com.konkuk.medicarecall.ui.feature.statistics.viewmodel
 
+import com.konkuk.medicarecall.data.dto.response.StatisticsResponseDto
+
 /**
  * 주간 요약 통계 화면의 전체 상태를 담는 데이터 클래스
  * - 식사율, 복약율, 건강징후, 미응답
@@ -12,104 +14,148 @@ package com.konkuk.medicarecall.ui.feature.statistics.viewmodel
 
 data class WeeklySummaryUiState(
     val elderName: String = "",
-    val weeklyMealRate: Int,
-    val weeklyMedicineRate: Int,
-    val weeklyHealthIssueCount: Int,
-    val weeklyUnansweredCount: Int,
+    val weeklyMealRate: Int? = null,
+    val weeklyMedicineRate: Int? = null,
+    val weeklyHealthIssueCount: Int? = null,
+    val weeklyUnansweredCount: Int? = null,
 
     val weeklyMeals: List<WeeklyMealUiState> = emptyList(),
     val weeklyMedicines: List<WeeklyMedicineUiState> = emptyList(),
     val weeklyHealthNote: String = "",
-    val weeklySleepHours: Int? = 0,
-    val weeklySleepMinutes: Int? = 0,
-    val weeklySleepRecorded: Boolean = true,
+    val weeklySleepHours: Int? = null,
+    val weeklySleepMinutes: Int? = null,
+    val weeklySleepRecorded: Boolean = false,
     val weeklyMental: WeeklyMentalUiState = WeeklyMentalUiState.EMPTY,
     val weeklyGlucose: WeeklyGlucoseUiState = WeeklyGlucoseUiState.EMPTY,
-) {
-    companion object {
+    val unreadNotification: Int? = null,
 
-        val EMPTY = WeeklySummaryUiState(
-            elderName = "",
-            weeklyMealRate = -1,
-            weeklyMedicineRate = -1,
-            weeklyHealthIssueCount = -1,
-            weeklyUnansweredCount = -1,
-            weeklyMeals = listOf(
-                WeeklyMealUiState("아침", -1, 7),
-                WeeklyMealUiState("점심", -1, 7),
-                WeeklyMealUiState("저녁", -1, 7),
-            ),
-            weeklyMedicines = emptyList(),
-            weeklyHealthNote = "",
-            weeklySleepHours = null,
-            weeklySleepMinutes = null,
-            weeklyMental = WeeklyMentalUiState.EMPTY,
-            weeklyGlucose = WeeklyGlucoseUiState.EMPTY,
-        )
+    ) {
+    companion object {
+        val EMPTY = WeeklySummaryUiState() // 전부 null/빈값
+        fun from(dto: StatisticsResponseDto, medicineNames: List<String>): WeeklySummaryUiState {
+            val stats = dto.summaryStats
+            val meals = dto.mealStats
+            val meds = dto.medicationStats
+
+            val sleepH = dto.averageSleep?.hours
+            val sleepM = dto.averageSleep?.minutes
+
+            // 복약 데이터 처리
+            val weeklyMedicines = when {
+                !meds.isNullOrEmpty() -> meds.entries.map { (name, s) ->
+                    WeeklyMedicineUiState(
+                        medicineName = name,
+                        takenCount = s.takenCount,
+                        totalCount = s.totalCount ?: 0,
+                    )
+                }
+
+                medicineNames.isNotEmpty() -> medicineNames.map { name ->
+                    WeeklyMedicineUiState(
+                        medicineName = name,
+                        takenCount = null, // 미기록 상태
+                        totalCount = 0,
+                    )
+                }
+
+                else -> emptyList()
+            }
+
+            return WeeklySummaryUiState(
+                elderName = dto.elderName.orEmpty(),
+                weeklyMealRate = stats?.mealRate,
+                weeklyMedicineRate = stats?.medicationRate,
+                weeklyHealthIssueCount = stats?.healthSignals,
+                weeklyUnansweredCount = stats?.missedCalls,
+                weeklyMeals = listOf(
+                    WeeklyMealUiState("아침", meals?.breakfast, 7),
+                    WeeklyMealUiState("점심", meals?.lunch, 7),
+                    WeeklyMealUiState("저녁", meals?.dinner, 7),
+                ),
+                weeklyMedicines = weeklyMedicines,
+                weeklyHealthNote = dto.healthSummary.orEmpty(),
+                weeklySleepHours = sleepH,
+                weeklySleepMinutes = sleepM,
+                weeklySleepRecorded = (sleepH ?: 0) > 0 || (sleepM ?: 0) > 0,
+                weeklyMental = WeeklyMentalUiState(
+                    good = dto.psychSummary?.good ?: 0,
+                    normal = dto.psychSummary?.normal ?: 0,
+                    bad = dto.psychSummary?.bad ?: 0,
+                ),
+                weeklyGlucose = WeeklyGlucoseUiState(
+                    beforeMealNormal = dto.bloodSugar?.beforeMeal?.normal ?: 0,
+                    beforeMealHigh = dto.bloodSugar?.beforeMeal?.high ?: 0,
+                    beforeMealLow = dto.bloodSugar?.beforeMeal?.low ?: 0,
+                    afterMealNormal = dto.bloodSugar?.afterMeal?.normal ?: 0,
+                    afterMealHigh = dto.bloodSugar?.afterMeal?.high ?: 0,
+                    afterMealLow = dto.bloodSugar?.afterMeal?.low ?: 0,
+                ),
+                unreadNotification = dto.unreadNotification,
+            )
+        }
     }
-}
 
-/**
- * ✅ 아침/점심/저녁 식사 통계용
- * ex) 아침 7/7, 점심 5/7, 저녁 1/7
- */
-data class WeeklyMealUiState(
-    val mealType: String, // 예: "아침"
-    val eatenCount: Int?, // 실제 완료 횟수
-    val totalCount: Int, // 총 예정 횟수 (보통 7)
-)
+    /**
+     * ✅ 아침/점심/저녁 식사 통계용
+     * ex) 아침 7/7, 점심 5/7, 저녁 1/7
+     */
+    data class WeeklyMealUiState(
+        val mealType: String, // 예: "아침"
+        val eatenCount: Int?, // 실제 완료 횟수
+        val totalCount: Int, // 총 예정 횟수 (보통 7)
+    )
 
-/**
- * ✅ 복약 통계용
- * ex) 혈압약 0/14, 영양제 4/7, 당뇨약 21/21
- */
-data class WeeklyMedicineUiState(
-    val medicineName: String, // 예: "혈압약"
-    val takenCount: Int?, // 완료 횟수
-    val totalCount: Int, // 총 예정 횟수
-)
+    /**
+     * ✅ 복약 통계용
+     * ex) 혈압약 0/14, 영양제 4/7, 당뇨약 21/21
+     */
+    data class WeeklyMedicineUiState(
+        val medicineName: String, // 예: "혈압약"
+        val takenCount: Int?, // 완료 횟수
+        val totalCount: Int, // 총 예정 횟수
+    )
 
-/**
- * ✅ 심리 상태 통계용
- * ex) 좋음 4, 보통 4, 나쁨 4
- */
-data class WeeklyMentalUiState(
-    val good: Int, // 좋음 횟수
-    val normal: Int, // 보통 횟수
-    val bad: Int, // 나쁨 횟수
-) {
-
-    companion object {
-        val EMPTY = WeeklyMentalUiState(
-            good = -1,
-            normal = -1,
-            bad = -1,
-        )
+    /**
+     * ✅ 심리 상태 통계용
+     * ex) 좋음 4, 보통 4, 나쁨 4
+     */
+    data class WeeklyMentalUiState(
+        val good: Int, // 좋음 횟수
+        val normal: Int, // 보통 횟수
+        val bad: Int, // 나쁨 횟수
+    ) {
+        companion object {
+            val EMPTY = WeeklyMentalUiState(
+                good = -1,
+                normal = -1,
+                bad = -1,
+            )
+        }
     }
-}
 
-/**
- * ✅ 혈당 공복/식후 통계용
- * ex) 공복: 정상 5, 높음 2, 낮음 1
- * 식후: 정상 5, 높음 0, 낮음 2
- */
-data class WeeklyGlucoseUiState(
-    val beforeMealNormal: Int, // 공복 정상 횟수
-    val beforeMealHigh: Int, // 공복 높음 횟수
-    val beforeMealLow: Int, // 공복 낮음 횟수
+    /**
+     * ✅ 혈당 공복/식후 통계용
+     * ex) 공복: 정상 5, 높음 2, 낮음 1
+     * 식후: 정상 5, 높음 0, 낮음 2
+     */
+    data class WeeklyGlucoseUiState(
+        val beforeMealNormal: Int, // 공복 정상 횟수
+        val beforeMealHigh: Int, // 공복 높음 횟수
+        val beforeMealLow: Int, // 공복 낮음 횟수
 
-    val afterMealNormal: Int, // 식후 정상 횟수
-    val afterMealHigh: Int, // 식후 높음 횟수
-    val afterMealLow: Int, // 식후 낮음 횟수
-) {
-    companion object {
-        val EMPTY = WeeklyGlucoseUiState(
-            beforeMealNormal = 0,
-            beforeMealHigh = 0,
-            beforeMealLow = 0,
-            afterMealNormal = 0,
-            afterMealHigh = 0,
-            afterMealLow = 0,
-        )
+        val afterMealNormal: Int, // 식후 정상 횟수
+        val afterMealHigh: Int, // 식후 높음 횟수
+        val afterMealLow: Int, // 식후 낮음 횟수
+    ) {
+        companion object {
+            val EMPTY = WeeklyGlucoseUiState(
+                beforeMealNormal = 0,
+                beforeMealHigh = 0,
+                beforeMealLow = 0,
+                afterMealNormal = 0,
+                afterMealHigh = 0,
+                afterMealLow = 0,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/WeeklySummaryUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/WeeklySummaryUiState.kt
@@ -28,8 +28,7 @@ data class WeeklySummaryUiState(
     val weeklyMental: WeeklyMentalUiState = WeeklyMentalUiState.EMPTY,
     val weeklyGlucose: WeeklyGlucoseUiState = WeeklyGlucoseUiState.EMPTY,
     val unreadNotification: Int? = null,
-
-    ) {
+) {
     companion object {
         val EMPTY = WeeklySummaryUiState() // 전부 null/빈값
         fun from(dto: StatisticsResponseDto, medicineNames: List<String>): WeeklySummaryUiState {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyGlucoseCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyGlucoseCard.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyGlucoseUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState
 import com.konkuk.medicarecall.ui.theme.LocalMediCareCallShadowProvider
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow
@@ -31,7 +31,7 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 @Composable
 fun WeeklyGlucoseCard(
     modifier: Modifier = Modifier,
-    weeklyGlucose: WeeklyGlucoseUiState,
+    weeklyGlucose: WeeklySummaryUiState.WeeklyGlucoseUiState,
 ) {
     val hasBeforeMealData =
         weeklyGlucose.beforeMealNormal > 0 || weeklyGlucose.beforeMealHigh > 0 || weeklyGlucose.beforeMealLow > 0
@@ -191,7 +191,7 @@ private fun GlucoseStatusRow(
 @Composable
 fun PreviewWeeklyGlucoseCardRecorded() {
     WeeklyGlucoseCard(
-        weeklyGlucose = WeeklyGlucoseUiState(
+        weeklyGlucose = WeeklySummaryUiState.WeeklyGlucoseUiState(
             beforeMealNormal = 5,
             beforeMealHigh = 2,
             beforeMealLow = 1,
@@ -206,6 +206,6 @@ fun PreviewWeeklyGlucoseCardRecorded() {
 @Composable
 fun PreviewWeeklyGlucoseCardUnrecorded() {
     WeeklyGlucoseCard(
-        weeklyGlucose = WeeklyGlucoseUiState.EMPTY,
+        weeklyGlucose = WeeklySummaryUiState.WeeklyGlucoseUiState.EMPTY,
     )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMealCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMealCard.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.R
 import com.konkuk.medicarecall.ui.common.util.WeeklySummaryUtil
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMealUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState.WeeklyMealUiState
 import com.konkuk.medicarecall.ui.theme.LocalMediCareCallShadowProvider
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMedicineCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMedicineCard.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.R
 import com.konkuk.medicarecall.ui.common.util.WeeklySummaryUtil
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMedicineUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState.WeeklyMedicineUiState
 import com.konkuk.medicarecall.ui.theme.LocalMediCareCallShadowProvider
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMentalCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklyMentalCard.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.R
-import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklyMentalUiState
+import com.konkuk.medicarecall.ui.feature.statistics.viewmodel.WeeklySummaryUiState
 import com.konkuk.medicarecall.ui.theme.LocalMediCareCallShadowProvider
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow
@@ -31,7 +31,7 @@ import com.konkuk.medicarecall.ui.theme.figmaShadow
 @Composable
 fun WeeklyMentalCard(
     modifier: Modifier = Modifier,
-    mental: WeeklyMentalUiState,
+    mental: WeeklySummaryUiState.WeeklyMentalUiState,
 ) {
     Card(
         modifier = modifier
@@ -122,7 +122,7 @@ private fun MentalStatusRow(
 fun PreviewWeeklyMentalCardRecorded() {
     WeeklyMentalCard(
         modifier = Modifier.size(155.dp),
-        mental = WeeklyMentalUiState(
+        mental = WeeklySummaryUiState.WeeklyMentalUiState(
             good = 4,
             normal = 2,
             bad = 1,
@@ -135,6 +135,6 @@ fun PreviewWeeklyMentalCardRecorded() {
 fun PreviewWeeklyMentalCardUnrecorded() {
     WeeklyMentalCard(
         modifier = Modifier.size(155.dp),
-        mental = WeeklyMentalUiState.EMPTY,
+        mental = WeeklySummaryUiState.WeeklyMentalUiState.EMPTY,
     )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklySummaryCard.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/statistics/weeklycard/WeeklySummaryCard.kt
@@ -79,10 +79,13 @@ fun WeeklySummaryCard(
 private fun WeeklySummaryItem(
     modifier: Modifier = Modifier,
     title: String,
-    value: Int,
+    value: Int?,
     unit: String,
 ) {
-    val isUnrecorded = if (title != "건강징후") value <= 0 else value < 0
+    val isUnrecorded = when (value) {
+        null -> true
+        else -> if (title != "건강징후") value <= 0 else value < 0
+    }
     val valueText = if (isUnrecorded) "-" else value.toString()
 
     Column(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
@@ -17,11 +17,11 @@ import com.konkuk.medicarecall.data.dto.response.NoticesResponseDto
 import com.konkuk.medicarecall.ui.feature.alarm.navigation.navigateToAlarm
 import com.konkuk.medicarecall.ui.feature.home.navigation.navigateToHome
 import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToGlucoseDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateHealthDetailScreen
 import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToMealDetailScreen
 import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToMedicineDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateMentalDetailScreen
 import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToSleepDetailScreen
+import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateHealthDetailScreen
+import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateMentalDetailScreen
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginCareCallSetting
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginFinish
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginNaverPayView

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -102,9 +102,8 @@ fun NavGraph(
 
         // 알림 네비게이션
         alarmNavGraph(
-            popBackStack = { navController.popBackStack() }
+            popBackStack = { navController.popBackStack() },
         )
-
 
         // 홈
 //        composable<MainTabRoute.Home> { backStackEntry ->

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -15,7 +15,7 @@ import com.konkuk.medicarecall.data.dto.response.EldersInfoResponseDto
 import com.konkuk.medicarecall.data.dto.response.EldersSubscriptionResponseDto
 import com.konkuk.medicarecall.data.dto.response.MyInfoResponseDto
 import com.konkuk.medicarecall.data.dto.response.NoticesResponseDto
-import com.konkuk.medicarecall.ui.feature.alarm.screen.AlarmScreen
+import com.konkuk.medicarecall.ui.feature.alarm.navigation.alarmNavGraph
 import com.konkuk.medicarecall.ui.feature.home.navigation.homeNavGraph
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.screen.GlucoseDetailScreen
@@ -100,6 +100,12 @@ fun NavGraph(
             )
         }
 
+        // 알림 네비게이션
+        alarmNavGraph(
+            popBackStack = { navController.popBackStack() }
+        )
+
+
         // 홈
 //        composable<MainTabRoute.Home> { backStackEntry ->
 //            HomeScreen(
@@ -118,6 +124,7 @@ fun NavGraph(
             navigateToStateHealthDetailScreen = navigator::navigateToStateHealthDetailScreen,
             navigateToStateMentalDetailScreen = navigator::navigateToStateMentalDetailScreen,
             navigateToGlucoseDetailScreen = navigator::navigateToGlucoseDetailScreen,
+            navigateToAlarmScreen = { navigator.navigateToAlarm() },
         )
 
         // 홈 상세 화면_식사 화면
@@ -172,6 +179,7 @@ fun NavGraph(
             StatisticsScreen(
                 navController = navController,
                 homeViewModel = homeViewModel,
+                navigateToAlarm = { navController.navigate(Route.Alarm) },
             )
         }
 
@@ -363,14 +371,6 @@ fun NavGraph(
 //            navigateToUserInfoSetting = navigator::navigateToUserInfoSetting,
 //            navigateToLoginAfterLogout = navigator::navigateToLoginAfterLogout
 //        )
-
-        composable<Route.Alarm> {
-            AlarmScreen(
-                onBack = {
-                    navController.popBackStack()
-                },
-            )
-        }
 
         // 로그인 내비게이션
         composable<Route.LoginStart> {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #171 

## 📙 작업 설명
- 서버 미기록 응답(null)이 변경됨에 따라, 홈화면과 주간 통계 화면에 반영하였습니다.
   Dto 필드의 모든 타입을 널러블하게 수정했습니다. 
   누락된 필드를 안전하게 파싱할 수 있도록 기본값을 ? = null로 설정했습니다.
   UI State에서도 null값을 그대로 받을 수 있도록 수정했습니다. 
   StatisticsViewModel에 있던 DTO 변환 로직을 WeeklySummaryUiState의 from() 팩토리 메서드로   
   분리했습니다.
- 홈->알림/ 주간통계->알림화면으로 이동기능 수정
   NameBar의 알림아이콘 클릭시, 알림화면을 호출하고 이동하도록 변경하였습니다
   
## 💬 추가 설명 or 리뷰 포인트 (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 요약 필드 추가 및 홈/통계 화면에 읽지 않은 알림 수 표시

* **개선사항**
  * 홈·통계에서 알람 화면 이동 네비게이션 추가
  * 데이터 null 안전성 강화 — 미기록 시 "-" 또는 "미기록" 노출
  * 약 복용 회차 및 다음 복용 시간 표시 개선, 혈당·수면·정신 상태 처리 보완

* **버그 수정/안정성**
  * 알림 아이콘 클릭 대상 조정 및 아이콘 크기 변경, 동적 카운트 반영
  * UI 변환 경로 간소화로 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->