### PR TITLE
[Fix] 어르신이 고정되어 상세화면에서 어르신이 변경되지 않는 문제 #185

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
@@ -12,22 +12,34 @@ fun NavController.navigateToHome(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.homeNavGraph(
-    navigateToMealDetailScreen: () -> Unit,
-    navigateToMedicineDetailScreen: () -> Unit,
-    navigateToSleepDetailScreen: () -> Unit,
-    navigateToStateHealthDetailScreen: () -> Unit,
-    navigateToStateMentalDetailScreen: () -> Unit,
-    navigateToGlucoseDetailScreen: () -> Unit,
+    navigateToMealDetailScreen: (Int) -> Unit,
+    navigateToMedicineDetailScreen: (Int) -> Unit,
+    navigateToSleepDetailScreen: (Int) -> Unit,
+    navigateToStateHealthDetailScreen: (Int) -> Unit,
+    navigateToStateMentalDetailScreen: (Int) -> Unit,
+    navigateToGlucoseDetailScreen: (Int) -> Unit,
     navigateToAlarmScreen: () -> Unit,
 ) {
     composable<MainTabRoute.Home> { backStackEntry ->
         HomeScreen(
-            navigateToMealDetailScreen = navigateToMealDetailScreen,
-            navigateToMedicineDetailScreen = navigateToMedicineDetailScreen,
-            navigateToSleepDetailScreen = navigateToSleepDetailScreen,
-            navigateToStateHealthDetailScreen = navigateToStateHealthDetailScreen,
-            navigateToStateMentalDetailScreen = navigateToStateMentalDetailScreen,
-            navigateToGlucoseDetailScreen = navigateToGlucoseDetailScreen,
+            navigateToMealDetailScreen = { elderId ->
+                navigateToMealDetailScreen(elderId)
+            },
+            navigateToMedicineDetailScreen = { elderId ->
+                navigateToMedicineDetailScreen(elderId)
+            },
+            navigateToSleepDetailScreen = { elderId ->
+                navigateToSleepDetailScreen(elderId)
+            },
+            navigateToStateHealthDetailScreen = { elderId ->
+                navigateToStateHealthDetailScreen(elderId)
+            },
+            navigateToStateMentalDetailScreen = { elderId ->
+                navigateToStateMentalDetailScreen(elderId)
+            },
+            navigateToGlucoseDetailScreen = { elderId ->
+                navigateToGlucoseDetailScreen(elderId)
+            },
             mainBackStackEntry = backStackEntry,
             navigateToAlarm = navigateToAlarmScreen,
         )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -73,12 +73,12 @@ import kotlinx.coroutines.launch
 fun HomeScreen(
     modifier: Modifier = Modifier,
     homeViewModel: HomeViewModel = hiltViewModel(),
-    navigateToMealDetailScreen: () -> Unit,
-    navigateToMedicineDetailScreen: () -> Unit,
-    navigateToSleepDetailScreen: () -> Unit,
-    navigateToStateHealthDetailScreen: () -> Unit,
-    navigateToStateMentalDetailScreen: () -> Unit,
-    navigateToGlucoseDetailScreen: () -> Unit,
+    navigateToMealDetailScreen: (Int) -> Unit,
+    navigateToMedicineDetailScreen: (Int) -> Unit,
+    navigateToSleepDetailScreen: (Int) -> Unit,
+    navigateToStateHealthDetailScreen: (Int) -> Unit,
+    navigateToStateMentalDetailScreen: (Int) -> Unit,
+    navigateToGlucoseDetailScreen: (Int) -> Unit,
     mainBackStackEntry: NavBackStackEntry,
     navigateToAlarm: () -> Unit,
 ) {
@@ -117,12 +117,13 @@ fun HomeScreen(
             homeViewModel.selectElder(selectedName)
             dropdownOpened = false
         },
-        navigateToMealDetailScreen = navigateToMealDetailScreen,
-        navigateToMedicineDetailScreen = navigateToMedicineDetailScreen,
-        navigateToSleepDetailScreen = navigateToSleepDetailScreen,
-        navigateToStateHealthDetailScreen = navigateToStateHealthDetailScreen,
-        navigateToStateMentalDetailScreen = navigateToStateMentalDetailScreen,
-        navigateToGlucoseDetailScreen = navigateToGlucoseDetailScreen,
+        navigateToMealDetailScreen = { selectedElderId?.let(navigateToMealDetailScreen) },
+        navigateToMedicineDetailScreen = { selectedElderId?.let(navigateToMedicineDetailScreen) },
+        navigateToSleepDetailScreen = { selectedElderId?.let(navigateToSleepDetailScreen) },
+        navigateToStateHealthDetailScreen = { selectedElderId?.let(navigateToStateHealthDetailScreen) },
+        navigateToStateMentalDetailScreen = { selectedElderId?.let(navigateToStateMentalDetailScreen) },
+        navigateToGlucoseDetailScreen = { selectedElderId?.let(navigateToGlucoseDetailScreen) },
+
         navigateToAlarm = navigateToAlarm,
 
         snackbarHostState = snackbarHostState,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.konkuk.medicarecall.R
 import com.konkuk.medicarecall.ui.common.component.TopAppBar
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.component.GlucoseGraph
 import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.component.GlucoseListItem
 import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.component.GlucoseStatusItem
@@ -108,16 +107,25 @@ fun GlucoseDetailScreen(
     // 무한 스크롤 (더 빠른 트리거와 중복 요청 방지)
     LaunchedEffect(scrollState.value, scrollState.maxValue) {
         Log.d("scroll", "value: ${scrollState.value}, max: ${scrollState.maxValue}, isLoading: ${uiState.isLoading}, hasNext: ${uiState.hasNext}")
-
-        // 더 일찍 트리거 (500dp 전에 미리 로딩)
+        // 스크롤이 거의 끝까지 왔을 때만 다음 페이지 불러오기
         val shouldLoad = scrollState.value > scrollState.maxValue - 500 || scrollState.maxValue <= 100
 
-        if (shouldLoad && elderId != null && !uiState.isLoading && uiState.hasNext && !isRequestingMore.value) {
+        if (shouldLoad &&
+            !uiState.isLoading &&
+            uiState.hasNext &&
+            !isRequestingMore.value
+        ) {
             isRequestingMore.value = true
             val currentTiming = uiState.selectedTiming
             val currentPage = counter.getValue(currentTiming)
-            Log.d("scroll", "Loading page ${currentPage + 1} for $currentTiming")
-            viewModel.getGlucoseData(elderId!!, currentPage + 1, currentTiming, false)
+
+            glucoseViewModel.getGlucoseData(
+                elderId = elderId,
+                counter = currentPage + 1,    // 다음 페이지 요청
+                type = currentTiming,
+                isRefresh = false,
+            )
+
             counter[currentTiming] = currentPage + 1
         }
     }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
@@ -62,11 +62,7 @@ fun GlucoseDetailScreen(
     val scrollState = rememberScrollState()
     val uiState by glucoseViewModel.uiState.collectAsStateWithLifecycle()
 
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    // 선택된 어르신 ID를 구독 (null 가능)
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
-
+    // 페이지 카운터
     val counter = remember {
         mutableStateMapOf(
             GlucoseTiming.BEFORE_MEAL to 0,
@@ -74,20 +70,28 @@ fun GlucoseDetailScreen(
         )
     }
 
-    val coroutineScope = rememberCoroutineScope()
-
     // 로딩 요청 중복 방지를 위한 플래그
     val isRequestingMore = remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
     // 데이터 새로고침 로직
     val refreshData = remember(glucoseViewModel) {
         {
-            elderId?.let { id ->
-                counter[GlucoseTiming.BEFORE_MEAL] = 0
-                counter[GlucoseTiming.AFTER_MEAL] = 0
-                viewModel.getGlucoseData(id, 0, GlucoseTiming.BEFORE_MEAL, true)
-                viewModel.getGlucoseData(id, 0, GlucoseTiming.AFTER_MEAL, true)
-            }
+            counter[GlucoseTiming.BEFORE_MEAL] = 0
+            counter[GlucoseTiming.AFTER_MEAL] = 0
+
+            glucoseViewModel.getGlucoseData(
+                elderId = elderId,
+                counter = 0,
+                type = GlucoseTiming.BEFORE_MEAL,
+                isRefresh = true,
+            )
+            glucoseViewModel.getGlucoseData(
+                elderId = elderId,
+                counter = 0,
+                type = GlucoseTiming.AFTER_MEAL,
+                isRefresh = true,
+            )
         }
     }
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
@@ -121,7 +121,7 @@ fun GlucoseDetailScreen(
 
             glucoseViewModel.getGlucoseData(
                 elderId = elderId,
-                counter = currentPage + 1,    // 다음 페이지 요청
+                counter = currentPage + 1, // 다음 페이지 요청
                 type = currentTiming,
                 isRefresh = false,
             )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
@@ -55,13 +55,12 @@ import java.time.LocalDate
 @Composable
 fun GlucoseDetailScreen(
     modifier: Modifier = Modifier,
+    elderId: Int,
     onBack: () -> Unit,
+    glucoseViewModel: GlucoseViewModel = hiltViewModel(),
 ) {
     val scrollState = rememberScrollState()
-
-    // 어르신 선택 상태(selectedElderId) 관리
-    val homeViewModel: HomeViewModel = hiltViewModel()
-    val viewModel: GlucoseViewModel = hiltViewModel()
+    val uiState by glucoseViewModel.uiState.collectAsStateWithLifecycle()
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -81,7 +80,7 @@ fun GlucoseDetailScreen(
     val isRequestingMore = remember { mutableStateOf(false) }
 
     // 데이터 새로고침 로직
-    val refreshData = remember(viewModel) {
+    val refreshData = remember(glucoseViewModel) {
         {
             elderId?.let { id ->
                 counter[GlucoseTiming.BEFORE_MEAL] = 0
@@ -134,13 +133,11 @@ fun GlucoseDetailScreen(
 
         // '공복'/'식후' 버튼
         onTimingChange = { newTiming ->
-            viewModel.updateTiming(newTiming)
-            coroutineScope.launch {
-                scrollState.scrollTo(0)
-            }
+            glucoseViewModel.updateTiming(newTiming)
+            coroutineScope.launch { scrollState.scrollTo(0) }
         },
         // 그래프 점
-        onPointClick = { newIndex -> viewModel.onClickDots(newIndex) },
+        onPointClick = glucoseViewModel::onClickDots,
         scrollState = scrollState,
         onBack = onBack,
     )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/screen/MealDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/screen/MealDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.konkuk.medicarecall.ui.feature.homedetail.meal.screen
 
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -28,7 +27,6 @@ import com.konkuk.medicarecall.ui.feature.calendar.DateSelector
 import com.konkuk.medicarecall.ui.feature.calendar.WeeklyCalendar
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarUiState
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.component.MealDetailCard
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealViewModel
@@ -38,8 +36,8 @@ import java.time.LocalDate
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MealDetailScreen(
+    elderId: Int,
     onBack: () -> Unit,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
     mealViewModel: MealViewModel = hiltViewModel(),
 ) {
@@ -47,24 +45,21 @@ fun MealDetailScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         calendarViewModel.resetToToday()
     }
-
+    // 날짜만 Observe
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
+    val meals by mealViewModel.meals.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {
-        Log.d("MED_UI", "LaunchedEffect: elderId=$elderId, date=$selectedDate")
-        elderId?.let { mealViewModel.loadMealsForDate(it, selectedDate) }
+        mealViewModel.loadMealsForDate(elderId, selectedDate)
     }
-
-    val meals by mealViewModel.meals.collectAsStateWithLifecycle()
 
     MealDetailScreenLayout(
         onBack = onBack,
         selectedDate = selectedDate,
         meals = meals,
         weekDates = calendarViewModel.getCurrentWeekDates(),
-        onDateSelected = { calendarViewModel.selectDate(it) },
+        onDateSelected = calendarViewModel::selectDate,
         onMonthClick = { /* 모달 열기 */ },
     )
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/screen/MedicineDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/screen/MedicineDetailScreen.kt
@@ -28,7 +28,6 @@ import com.konkuk.medicarecall.ui.feature.calendar.DateSelector
 import com.konkuk.medicarecall.ui.feature.calendar.WeeklyCalendar
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarUiState
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.component.MedicineDetailCard
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.DoseStatus
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.DoseStatusItem
@@ -40,8 +39,8 @@ import java.time.LocalDate
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MedicineDetailScreen(
+    elderId: Int,
     onBack: () -> Unit,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
     medicineViewModel: MedicineViewModel = hiltViewModel(),
 ) {
@@ -51,7 +50,6 @@ fun MedicineDetailScreen(
     }
 
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/navigation/HomeDetailNavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/navigation/HomeDetailNavGraph.kt
@@ -67,7 +67,7 @@ fun NavGraphBuilder.homeDetailNavGraph(
     }
 
     // 홈 상세 화면_건강 징후 화면
-    composable<Route.StateHealthDetail> {backStackEntry ->
+    composable<Route.StateHealthDetail> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.StateHealthDetail>()
         StateHealthDetailScreen(
             elderId = route.elderId,
@@ -76,7 +76,7 @@ fun NavGraphBuilder.homeDetailNavGraph(
     }
 
     // 홈 상세 화면_심리 상태 화면
-    composable<Route.StateMentalDetail> {backStackEntry ->
+    composable<Route.StateMentalDetail> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.StateMentalDetail>()
         StateMentalDetailScreen(
             elderId = route.elderId,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/navigation/HomeDetailNavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/navigation/HomeDetailNavGraph.kt
@@ -3,6 +3,7 @@ package com.konkuk.medicarecall.ui.feature.homedetail.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.screen.GlucoseDetailScreen
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.screen.MealDetailScreen
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.screen.MedicineDetailScreen
@@ -11,62 +12,84 @@ import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.screen.StateHea
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.screen.StateMentalDetailScreen
 import com.konkuk.medicarecall.ui.navigation.Route
 
-fun NavController.navigateToMealDetailScreen() {
-    navigate(Route.MealDetail)
+fun NavController.navigateToMealDetailScreen(elderId: Int) {
+    navigate(Route.MealDetail(elderId))
 }
 
-fun NavController.navigateToMedicineDetailScreen() {
-    navigate(Route.MedicineDetail)
+fun NavController.navigateToMedicineDetailScreen(elderId: Int) {
+    navigate(Route.MedicineDetail(elderId))
 }
 
-fun NavController.navigateToSleepDetailScreen() {
-    navigate(Route.SleepDetail)
+fun NavController.navigateToSleepDetailScreen(elderId: Int) {
+    navigate(Route.SleepDetail(elderId))
 }
 
-fun NavController.navigateToStateHealthDetailScreen() {
-    navigate(Route.StateHealthDetail)
+fun NavController.navigateToStateHealthDetailScreen(elderId: Int) {
+    navigate(Route.StateHealthDetail(elderId))
 }
 
-fun NavController.navigateToStateMentalDetailScreen() {
-    navigate(Route.StateMentalDetail)
+fun NavController.navigateToStateMentalDetailScreen(elderId: Int) {
+    navigate(Route.StateMentalDetail(elderId))
 }
 
-fun NavController.navigateToGlucoseDetailScreen() {
-    navigate(Route.GlucoseDetail)
+fun NavController.navigateToGlucoseDetailScreen(elderId: Int) {
+    navigate(Route.GlucoseDetail(elderId))
 }
 
 fun NavGraphBuilder.homeDetailNavGraph(
     popBackStack: () -> Unit,
 ) {
     // 홈 상세 화면_식사 화면
-    composable<Route.MealDetail> {
+    composable<Route.MealDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.MealDetail>()
         MealDetailScreen(
+            elderId = route.elderId,
             onBack = popBackStack,
         )
     }
 
     // 홈 상세 화면_복용 화면
-    composable<Route.MedicineDetail> {
-        MedicineDetailScreen(onBack = popBackStack)
+    composable<Route.MedicineDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.MedicineDetail>()
+        MedicineDetailScreen(
+            elderId = route.elderId,
+            onBack = popBackStack,
+        )
     }
 
     // 홈 상세 화면_수면 화면
-    composable<Route.SleepDetail> {
-        SleepDetailScreen(onBack = popBackStack)
+    composable<Route.SleepDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.SleepDetail>()
+        SleepDetailScreen(
+            elderId = route.elderId,
+            onBack = popBackStack,
+        )
     }
 
     // 홈 상세 화면_건강 징후 화면
-    composable<Route.StateHealthDetail> {
-        StateHealthDetailScreen(onBack = popBackStack)
+    composable<Route.StateHealthDetail> {backStackEntry ->
+        val route = backStackEntry.toRoute<Route.StateHealthDetail>()
+        StateHealthDetailScreen(
+            elderId = route.elderId,
+            onBack = popBackStack,
+        )
     }
 
     // 홈 상세 화면_심리 상태 화면
-    composable<Route.StateMentalDetail> {
-        StateMentalDetailScreen(onBack = popBackStack)
+    composable<Route.StateMentalDetail> {backStackEntry ->
+        val route = backStackEntry.toRoute<Route.StateMentalDetail>()
+        StateMentalDetailScreen(
+            elderId = route.elderId,
+            onBack = popBackStack,
+        )
     }
 
     // 홈 상세 화면_혈당 화면
-    composable<Route.GlucoseDetail> {
-        GlucoseDetailScreen(onBack = popBackStack)
+    composable<Route.GlucoseDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.GlucoseDetail>()
+        GlucoseDetailScreen(
+            elderId = route.elderId,
+            onBack = popBackStack,
+        )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/screen/SleepDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/screen/SleepDetailScreen.kt
@@ -26,7 +26,6 @@ import com.konkuk.medicarecall.ui.feature.calendar.DateSelector
 import com.konkuk.medicarecall.ui.feature.calendar.WeeklyCalendar
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarUiState
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.sleep.component.SleepDetailCard
 import com.konkuk.medicarecall.ui.feature.homedetail.sleep.viewmodel.SleepUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.sleep.viewmodel.SleepViewModel
@@ -36,8 +35,8 @@ import java.time.LocalDate
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SleepDetailScreen(
+    elderId: Int,
     onBack: () -> Unit,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
     sleepViewModel: SleepViewModel = hiltViewModel(),
 ) {
@@ -48,9 +47,6 @@ fun SleepDetailScreen(
 
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
     val sleep by sleepViewModel.sleep.collectAsStateWithLifecycle()
-
-    // 네임드롭에서 선택된 어르신
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -28,7 +28,6 @@ import com.konkuk.medicarecall.ui.feature.calendar.DateSelector
 import com.konkuk.medicarecall.ui.feature.calendar.WeeklyCalendar
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarUiState
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.component.StateHealthDetailCard
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthViewModel
@@ -37,8 +36,8 @@ import java.time.LocalDate
 
 @Composable
 fun StateHealthDetailScreen(
+    elderId: Int,
     onBack: () -> Unit,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
     healthViewModel: HealthViewModel = hiltViewModel(),
 ) {
@@ -51,9 +50,6 @@ fun StateHealthDetailScreen(
 
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
     val health by healthViewModel.health.collectAsStateWithLifecycle()
-
-    // 네임드롭에서 선택된 어르신
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/screen/StateMentalDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/screen/StateMentalDetailScreen.kt
@@ -27,7 +27,6 @@ import com.konkuk.medicarecall.ui.feature.calendar.DateSelector
 import com.konkuk.medicarecall.ui.feature.calendar.WeeklyCalendar
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarUiState
 import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
-import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.component.StateMentalDetailCard
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.MentalUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.MentalViewModel
@@ -37,8 +36,8 @@ import java.time.LocalDate
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun StateMentalDetailScreen(
+    elderId: Int,
     onBack: () -> Unit,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
     mentalViewModel: MentalViewModel = hiltViewModel(),
 ) {
@@ -49,9 +48,6 @@ fun StateMentalDetailScreen(
 
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
     val mental by mentalViewModel.mental.collectAsStateWithLifecycle()
-
-    // 네임드롭에서 선택된 어르신
-    val elderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
@@ -16,12 +16,6 @@ import com.konkuk.medicarecall.data.dto.response.MyInfoResponseDto
 import com.konkuk.medicarecall.data.dto.response.NoticesResponseDto
 import com.konkuk.medicarecall.ui.feature.alarm.navigation.navigateToAlarm
 import com.konkuk.medicarecall.ui.feature.home.navigation.navigateToHome
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToGlucoseDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToMealDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToMedicineDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToSleepDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateHealthDetailScreen
-import com.konkuk.medicarecall.ui.feature.homedetail.navigation.navigateToStateMentalDetailScreen
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginCareCallSetting
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginFinish
 import com.konkuk.medicarecall.ui.feature.login.navigation.navigateToLoginNaverPayView
@@ -139,28 +133,28 @@ class MainNavigator(
         this.navigateToMainTab(MainTab.HOME)
     }
 
-    fun navigateToMealDetailScreen() {
-        navController.navigateToMealDetailScreen()
+    fun navigateToMealDetailScreen(elderId: Int) {
+        navController.navigate(Route.MealDetail(elderId))
     }
 
-    fun navigateToMedicineDetailScreen() {
-        navController.navigateToMedicineDetailScreen()
+    fun navigateToMedicineDetailScreen(elderId: Int) {
+        navController.navigate(Route.MedicineDetail(elderId))
     }
 
-    fun navigateToSleepDetailScreen() {
-        navController.navigateToSleepDetailScreen()
+    fun navigateToSleepDetailScreen(elderId: Int) {
+        navController.navigate(Route.SleepDetail(elderId))
     }
 
-    fun navigateToStateHealthDetailScreen() {
-        navController.navigateToStateHealthDetailScreen()
+    fun navigateToStateHealthDetailScreen(elderId: Int) {
+        navController.navigate(Route.StateHealthDetail(elderId))
     }
 
-    fun navigateToStateMentalDetailScreen() {
-        navController.navigateToStateMentalDetailScreen()
+    fun navigateToStateMentalDetailScreen(elderId: Int) {
+        navController.navigate(Route.StateMentalDetail(elderId))
     }
 
-    fun navigateToGlucoseDetailScreen() {
-        navController.navigateToGlucoseDetailScreen()
+    fun navigateToGlucoseDetailScreen(elderId: Int) {
+        navController.navigate(Route.GlucoseDetail(elderId))
     }
 
     /* 설정 화면 */

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -128,42 +128,54 @@ fun NavGraph(
 
         // 홈 상세 화면_식사 화면
         composable<Route.MealDetail> {
+            val args = it.toRoute<Route.MealDetail>()
             MealDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }
 
         // 홈 상세 화면_복용 화면
         composable<Route.MedicineDetail> {
+            val args = it.toRoute<Route.MedicineDetail>()
             MedicineDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }
 
         // 홈 상세 화면_수면 화면
         composable<Route.SleepDetail> {
+            val args = it.toRoute<Route.SleepDetail>()
             SleepDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }
 
         // 홈 상세 화면_건강 징후 화면
         composable<Route.StateHealthDetail> {
+            val args = it.toRoute<Route.StateHealthDetail>()
             StateHealthDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }
 
         // 홈 상세 화면_심리 상태 화면
         composable<Route.StateMentalDetail> {
+            val args = it.toRoute<Route.StateMentalDetail>()
             StateMentalDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }
 
         // 홈 상세 화면_혈당 화면
         composable<Route.GlucoseDetail> {
+            val args = it.toRoute<Route.GlucoseDetail>()
             GlucoseDetailScreen(
+                elderId = args.elderId,
                 onBack = { navController.popBackStack() },
             )
         }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/Route.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/Route.kt
@@ -45,22 +45,22 @@ sealed interface Route {
 
     // 홈 (하루 요약)
     @Serializable
-    data object MealDetail : Route
+    data class MealDetail(val elderId: Int) : Route
 
     @Serializable
-    data object MedicineDetail : Route
+    data class MedicineDetail(val elderId: Int) : Route
 
     @Serializable
-    data object SleepDetail : Route
+    data class SleepDetail(val elderId: Int) : Route
 
     @Serializable
-    data object StateHealthDetail : Route
+    data class StateHealthDetail(val elderId: Int) : Route
 
     @Serializable
-    data object StateMentalDetail : Route
+    data class StateMentalDetail(val elderId: Int) : Route
 
     @Serializable
-    data object GlucoseDetail : Route
+    data class GlucoseDetail(val elderId: Int) : Route
 
     // 설정
     @Serializable


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #185 

## 📙 작업 설명
**문제**
- 네임드롭에서 어르신을 바꿔도 식사와 복약화면에서 어르신이 바뀌지 않는 문제를 확인했습니다
  AS-IS : 어르신 드롭다운으로 정대식(1043) → 상세화면 진입하면 여전히 양정애(1042) 기준

**원인**
- 상세 화면들이 HomeViewModel.selectedElderId 에 의존
- Navigation Route 에 elderId 전달이 없어서 항상 동일한 값 사용
- 혈당 화면은 HomeViewModel 의존 + 기존 페이지네이션 로직(스크롤시 API 여러번호출) 수정

**해결**
상세 화면을 route 기반 elderId 구조로 변경해 어르신 변경 미반영 문제 해결,
혈당 페이지네이션 로직 수정했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)

[Screen_recording_20251116_161751.webm](https://github.com/user-attachments/assets/20021918-af09-4f25-97d1-f71f86c75d5e)

## 💬 추가 설명 or 리뷰 포인트 (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **Refactor**
  * 각 디테일 화면으로 현재 선택된 어르신 식별자를 명시적으로 전달하도록 내비게이션을 재설계했습니다.
  * 식사·약·수면·건강·정신·혈당 화면이 전달된 식별자를 직접 사용해 데이터 로드 및 갱신을 수행하도록 변경해, 다중 보호자 환경에서 데이터 일관성과 복원성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->