### PR TITLE
[Fix] '다음' CTA 버튼 스크롤에 관계없이 고정 #187

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -85,6 +86,7 @@ fun LoginElderScreen(
             LoginBackButton(onClick = onBack)
             Column(
                 modifier
+                    .weight(1f)
                     .verticalScroll(scrollState),
             ) {
                 Spacer(Modifier.height(20.dp))
@@ -186,50 +188,53 @@ fun LoginElderScreen(
                 }
 
                 Spacer(Modifier.height(30.dp))
-                CTAButton(
-                    if (loginElderViewModel.isInputComplete())
-                        CTAButtonType.GREEN
-                    else CTAButtonType.DISABLED,
-                    "다음",
-                    {
-                        if (!uiState.eldersList.filter { it.name.isNotEmpty() }
-                                .all {
-                                    it.name.matches(Regex("^[가-힣a-zA-Z]*$"))
-                                }
-                        )
-                            coroutineScope.launch {
-                                snackBarState.showSnackbar(
-                                    "이름을 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short,
-                                )
-                            }
-                        else if (!uiState.eldersList.filter { it.birthDate.isNotEmpty() }
-                                .all {
-                                    it.birthDate.isValidDate()
-                                })
-                            coroutineScope.launch {
-                                snackBarState.showSnackbar(
-                                    "생년월일을 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short,
-                                )
-                            }
-                        else if (!uiState.eldersList.filter { it.phoneNumber.isNotEmpty() }
-                                .all { it.phoneNumber.startsWith("010") })
-                            coroutineScope.launch {
-                                snackBarState.showSnackbar(
-                                    "휴대폰 번호를 다시 확인해주세요",
-                                    duration = SnackbarDuration.Short,
-                                )
-                            }
-                        else {
-                            loginElderViewModel.initElderHealthData()
-                            loginElderViewModel.postElderBulk()
-                            navigateToRegisterElderHealth()
-                        }
-                    },
-                    modifier.padding(bottom = 20.dp),
-                )
+
             }
+
+
+            CTAButton(
+                if (loginElderViewModel.isInputComplete())
+                    CTAButtonType.GREEN
+                else CTAButtonType.DISABLED,
+                "다음",
+                {
+                    if (!uiState.eldersList.filter { it.name.isNotEmpty() }
+                            .all {
+                                it.name.matches(Regex("^[가-힣a-zA-Z]*$"))
+                            }
+                    )
+                        coroutineScope.launch {
+                            snackBarState.showSnackbar(
+                                "이름을 다시 확인해주세요",
+                                duration = SnackbarDuration.Short,
+                            )
+                        }
+                    else if (!uiState.eldersList.filter { it.birthDate.isNotEmpty() }
+                            .all {
+                                it.birthDate.isValidDate()
+                            })
+                        coroutineScope.launch {
+                            snackBarState.showSnackbar(
+                                "생년월일을 다시 확인해주세요",
+                                duration = SnackbarDuration.Short,
+                            )
+                        }
+                    else if (!uiState.eldersList.filter { it.phoneNumber.isNotEmpty() }
+                            .all { it.phoneNumber.startsWith("010") })
+                        coroutineScope.launch {
+                            snackBarState.showSnackbar(
+                                "휴대폰 번호를 다시 확인해주세요",
+                                duration = SnackbarDuration.Short,
+                            )
+                        }
+                    else {
+                        loginElderViewModel.initElderHealthData()
+                        loginElderViewModel.postElderBulk()
+                        navigateToRegisterElderHealth()
+                    }
+                },
+                Modifier.padding(top = 20.dp, bottom = 20.dp),
+            )
         }
 
         DefaultSnackBar(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderInfoScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -186,12 +185,8 @@ fun LoginElderScreen(
                         )
                     }
                 }
-
                 Spacer(Modifier.height(30.dp))
-
             }
-
-
             CTAButton(
                 if (loginElderViewModel.isInputComplete())
                     CTAButtonType.GREEN
@@ -236,7 +231,6 @@ fun LoginElderScreen(
                 Modifier.padding(top = 20.dp, bottom = 20.dp),
             )
         }
-
         DefaultSnackBar(
             snackBarState,
             Modifier

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
@@ -73,6 +73,7 @@ fun LoginElderMedInfoScreen(
             LoginBackButton(onBack)
             Column(
                 Modifier
+                    .weight(1f)
                     .verticalScroll(scrollState),
             ) {
                 Spacer(Modifier.height(30.dp))
@@ -179,18 +180,19 @@ fun LoginElderMedInfoScreen(
                         loginElderViewModel.addHealthNote(it)
                     },
                 )
-                CTAButton(
-                    CTAButtonType.GREEN,
-                    "다음",
-                    {
-                        coroutineScope.launch {
-                            loginElderViewModel.postElderHealthInfoBulk()
-                            navigateToCareCallSetting()
-                        }
-                    },
-                    Modifier.padding(top = 30.dp, bottom = 20.dp),
-                )
+
             }
+            CTAButton(
+                CTAButtonType.GREEN,
+                "다음",
+                {
+                    coroutineScope.launch {
+                        loginElderViewModel.postElderHealthInfoBulk()
+                        navigateToCareCallSetting()
+                    }
+                },
+                Modifier.padding(top = 20.dp, bottom = 20.dp),
+            )
         }
         DefaultSnackBar(
             snackBarState,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/login/senior/screen/LoginElderMedInfoScreen.kt
@@ -180,7 +180,6 @@ fun LoginElderMedInfoScreen(
                         loginElderViewModel.addHealthNote(it)
                     },
                 )
-
             }
             CTAButton(
                 CTAButtonType.GREEN,


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #187 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- '다음' CTA 버튼 스크롤에 관계없이 하단에 고정되도록 변경했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |
<img width="435" height="224" alt="image" src="https://github.com/user-attachments/assets/11db918b-0e16-487b-b085-7456eb8e7e13" />| 기능 설명 |<img src="링크" width="300" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## 출시 노트

* **스타일**
  * 내부 레이아웃 확장으로 스크롤 내 여백 활용을 개선합니다.
  * CTA 버튼 위치를 콘텐츠 아래로 이동하고 상하 패딩을 조정해 일관된 화면 구성을 제공합니다.

* **버그 수정**
  * 입력 검증 흐름을 정리해 실패 시 필드별 알림을 유지하고, 성공 시 데이터 초기화·전송 및 다음 화면으로의 이동을 안정적으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->