### PR TITLE
Fix : 네이버페이 화면으로 연결되는 거 삭제-#192

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.konkuk.medicarecall"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6
-        versionName = "0.1.5"
+        versionCode = 7
+        versionName = "0.1.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.konkuk.medicarecall"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5
-        versionName = "0.1.4"
+        versionCode = 6
+        versionName = "0.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/konkuk/medicarecall/data/repository/MemberRegisterRepository.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repository/MemberRegisterRepository.kt
@@ -1,7 +1,6 @@
 package com.konkuk.medicarecall.data.repository
 
 import com.konkuk.medicarecall.data.dto.response.MemberTokenResponseDto
-import com.konkuk.medicarecall.data.model.FcmToken
 import com.konkuk.medicarecall.ui.type.GenderType
 
 interface MemberRegisterRepository {
@@ -10,6 +9,6 @@ interface MemberRegisterRepository {
         name: String,
         birthDate: String,
         gender: GenderType,
-        fcmToken: String
+        fcmToken: String,
     ): Result<MemberTokenResponseDto>
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -467,7 +467,10 @@ fun NavGraph(
                     navController.popBackStack()
                 },
                 navigateToPayment = {
-                    navController.navigate(Route.LoginPurchase)
+                    //navController.navigate(Route.LoginPurchase)
+                    navController.navigate(Route.LoginFinish) {
+                        popUpTo(Route.LoginNaverPayView) { inclusive = true }
+                    }
                 },
             )
         }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -467,7 +467,6 @@ fun NavGraph(
                     navController.popBackStack()
                 },
                 navigateToPayment = {
-                    //navController.navigate(Route.LoginPurchase)
                     navController.navigate(Route.LoginFinish) {
                         popUpTo(Route.LoginNaverPayView) { inclusive = true }
                     }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #192 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
-

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 앱 버전을 0.1.6으로 업데이트했습니다.
  * 로그인 및 케어콜 설정 과정의 결제 후 이동 경로를 변경하여 결제 완료 후 최종 확인 화면으로 바로 이동합니다.
  * 결제 이후 이전 화면으로의 복귀(백스택) 처리를 조정해 중복 화면 진입을 줄이고 뒤로 가기 동작을 더 일관되게 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->