### PR TITLE
[Fix] 휴대폰 인증 -> 홈 이동시 뒤로가기 네비게이션 버그 수정 #190

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -87,7 +87,7 @@ fun NavGraph(
                 navigateToStart = { navController.navigate(Route.LoginStart) },
                 navigateToRegisterElder = { navController.navigate(Route.LoginRegisterElder) },
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
-                navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
+                navigateToPurchase = { navController.navigateToMainAfterLogin() },
                 navigateToHome = {
                     navController.navigateToMainAfterLogin()
                 },
@@ -383,7 +383,7 @@ fun NavGraph(
                 navigateToPhone = { navController.navigate(Route.LoginPhone) },
                 navigateToRegisterElder = { navController.navigate(Route.LoginRegisterElder) },
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
-                navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
+                navigateToPurchase = { navController.navigateToMainAfterLogin() },
                 navigateToHome = {
                     navController.navigateToMainAfterLogin()
                 },
@@ -408,7 +408,7 @@ fun NavGraph(
                 navigateToPhone = { navController.navigate(Route.LoginPhone) },
                 navigateToRegisterElder = { navController.navigate(Route.LoginRegisterElder) },
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
-                navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
+                navigateToPurchase = { navController.navigateToMainAfterLogin() },
                 navigateToHome = {
                     navController.navigateToMainAfterLogin()
                 },

--- a/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -56,9 +56,7 @@ import kotlin.reflect.typeOf
 // ---- 헬퍼: 로그인 성공 후 인증 그래프 제거하고 main으로 ---
 fun NavHostController.navigateToMainAfterLogin() {
     navigate(MainTabRoute.Home) {
-        popUpTo(Route.LoginStart) { inclusive = true }
-        launchSingleTop = true
-        restoreState = true
+        popUpTo(0) { inclusive = true }
     }
 }
 
@@ -91,11 +89,7 @@ fun NavGraph(
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
                 navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
                 navigateToHome = {
-                    navController.navigate(MainTabRoute.Home) {
-                        popUpTo(Route.LoginStart) {
-                            inclusive = true
-                        }
-                    }
+                    navController.navigateToMainAfterLogin()
                 },
             )
         }
@@ -391,11 +385,7 @@ fun NavGraph(
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
                 navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
                 navigateToHome = {
-                    navController.navigate(MainTabRoute.Home) {
-                        popUpTo(Route.LoginStart) {
-                            inclusive = true
-                        }
-                    }
+                    navController.navigateToMainAfterLogin()
                 },
                 loginViewModel = loginViewModel,
             )
@@ -420,11 +410,7 @@ fun NavGraph(
                 navigateToCareCallSetting = { navController.navigate(Route.LoginCareCallSetting) },
                 navigateToPurchase = { navController.navigate(MainTabRoute.Home) },
                 navigateToHome = {
-                    navController.navigate(MainTabRoute.Home) {
-                        popUpTo(Route.LoginStart) {
-                            inclusive = true
-                        }
-                    }
+                    navController.navigateToMainAfterLogin()
                 },
                 loginViewModel = loginViewModel,
             )


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #190

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 이제 popUpTo(0) 를 사용해서 홈으로 이동할 때 온보딩 backStack을 전부 삭제합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 로그인 후 홈 화면으로 이동할 때 네비게이션 흐름을 표준화하여 모든 로그인 경로에서 일관된 동작을 제공합니다.
  * 이전의 복잡한 백스택 복원 동작을 제거하고 단일 루트로 초기화 후 홈으로 이동하도록 개선했습니다.
  * 뒤로 가기 버튼 동작이 더 예측 가능하고 안정적으로 동작하도록 수정했습니다.
  * 전반적인 화면 전환 신뢰성을 향상시켜 로그인 경험이 일관되게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->