### PR TITLE
[Fix] 토큰 복호화 실패 시 방어 로직 구현 #198

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/data/util/TokenEncryptor.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/util/TokenEncryptor.kt
@@ -57,10 +57,14 @@ object TokenEncryptor {
     }
 
     fun decrypt(bytes: ByteArray): ByteArray {
-        val cipher = Cipher.getInstance(TRANSFORMATION)
-        val iv = bytes.copyOfRange(0, cipher.blockSize)
-        val data = bytes.copyOfRange(cipher.blockSize, bytes.size)
-        cipher.init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))
-        return cipher.doFinal(data)
+        return try {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val iv = bytes.copyOfRange(0, cipher.blockSize)
+            val data = bytes.copyOfRange(cipher.blockSize, bytes.size)
+            cipher.init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))
+            cipher.doFinal(data)
+        } catch (e: Exception) {
+            ByteArray(0)
+        }
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/util/TokenSerializer.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/util/TokenSerializer.kt
@@ -1,5 +1,6 @@
 package com.konkuk.medicarecall.data.util
 
+import android.util.Log
 import androidx.datastore.core.Serializer
 import com.konkuk.medicarecall.data.model.Token
 import kotlinx.coroutines.Dispatchers
@@ -17,13 +18,24 @@ object TokenSerializer : Serializer<Token> {
         get() = Token(null, null)
 
     override suspend fun readFrom(input: InputStream): Token {
-        val encryptedBytes = withContext(Dispatchers.IO) {
-            input.use { it.readBytes() }
+        return try {
+            val encryptedBytes = withContext(Dispatchers.IO) {
+                input.use { it.readBytes() }
+            }
+
+            // 빈 파일인 경우 기본값 반환
+            if (encryptedBytes.isEmpty()) {
+                return defaultValue
+            }
+
+            val encryptedBytesDecoded = Base64.getDecoder().decode(encryptedBytes)
+            val decryptedBytes = TokenEncryptor.decrypt(encryptedBytesDecoded)
+            val decodedJsonString = decryptedBytes.decodeToString()
+            Json.decodeFromString(decodedJsonString)
+        } catch (e: Exception) {
+            Log.d("TokenSerializer", "Failed to read Token: ${e.message}")
+            defaultValue
         }
-        val encryptedBytesDecoded = Base64.getDecoder().decode(encryptedBytes)
-        val decryptedBytes = TokenEncryptor.decrypt(encryptedBytesDecoded)
-        val decodedJsonString = decryptedBytes.decodeToString()
-        return Json.decodeFromString(decodedJsonString)
     }
 
     override suspend fun writeTo(t: Token, output: OutputStream) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #198 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 에러 발생 이유는 다음과 같습니다.
1. 앱 삭제 시
암호화 시 사용되었던 AES Keystore 가 삭제됨
DataStore 등 내부 저장소 데이터도 삭제됨
2. 앱 재설치 시
새로운 UID 가 발급되고, AES Keystore 가 새로 생김
**DataStore 가 복구됨!!** -> 이 값은 이전 AES Keystore 를 통해 암호화된 값임.
3. 실행
DataStore 에 값이 존재 -> decrypt 진행 -> 이전에 암호화된 값을 새로운 키로 복호화 하려고 함
에러 발생

- 해결 방법은 2가지가 있는 데 1안으로 선택했습니다.
1. decrypt 함수를 try-catch 로 감싸기
try catch 로 감싸서, 해당 예외가 발생 시 defaultValue 토큰으로 날림 -> 빈 토큰으로 인지해서 로그인화면으로 이동하게 됨
2. 메니페스트 파일에서 자동저장, 불러오기 false
<img width="521" height="243" alt="image" src="https://github.com/user-attachments/assets/9a477953-fefe-4392-9b90-7a1a8fab853f" />

위 사진에서 allowBackup, fullBackupContent 에 false 값을 입력하면 되는 것 같습니다.


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- https://developer.android.com/privacy-and-security/keystore?hl=ko
- https://stackoverflow.com/questions/31709308/android-key-store-entries-cleaning
