### PR TITLE
[Refactor] Home / HomeDetail / Calendar Koin 전환 및 Hilt 의존 제거 #210

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     kotlin("plugin.serialization") version "2.0.21"
     alias(libs.plugins.detekt)
@@ -107,10 +106,11 @@ dependencies {
     // WebView
     implementation("com.google.accompanist:accompanist-webview:0.24.13-rc")
 
-    // Hilt
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
+    // Koin
+    implementation("io.insert-koin:koin-core:3.5.3")
+    implementation("io.insert-koin:koin-android:3.5.3")
+    implementation("io.insert-koin:koin-androidx-compose:3.5.3")
+
 
     // Firebase
     implementation(platform(libs.firebase.bom))
@@ -119,7 +119,6 @@ dependencies {
 
     // Detekt formatting plugin
     detektPlugins(libs.detekt.formatting)
-    ksp(libs.hilt.manager)
 }
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {

--- a/app/src/main/java/com/konkuk/medicarecall/App.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/App.kt
@@ -7,24 +7,35 @@ import android.app.NotificationManager
 import android.os.Build
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessaging
+import com.konkuk.medicarecall.data.di.homeDetailModule
+import com.konkuk.medicarecall.data.di.homeModule
 import com.konkuk.medicarecall.data.repository.FcmRepository
-import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.context.startKoin
 
-@HiltAndroidApp
-class App : Application() {
-    @Inject
-    lateinit var fcmRepository: FcmRepository
+
+class App : Application(), KoinComponent {
+
+    private val fcmRepository: FcmRepository by inject()
 
     // Application 전체에서 쑬 수 있는 스코프(앱이 살아있는 동안 유지돼야 하는 초기화/저장 작업 진행 - 여러 초기화 작업 한덩어리로 관리)
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
+        startKoin {
+            androidContext(this@App)
+            modules(
+                homeModule,
+                homeDetailModule
+            )
+        }
         createNotificationChannel()
         fetchAndStoreFcmToken()
     }

--- a/app/src/main/java/com/konkuk/medicarecall/App.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/App.kt
@@ -19,7 +19,6 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 
-
 class App : Application(), KoinComponent {
 
     private val fcmRepository: FcmRepository by inject()
@@ -33,7 +32,7 @@ class App : Application(), KoinComponent {
             androidContext(this@App)
             modules(
                 homeModule,
-                homeDetailModule
+                homeDetailModule,
             )
         }
         createNotificationChannel()

--- a/app/src/main/java/com/konkuk/medicarecall/App.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/App.kt
@@ -7,6 +7,7 @@ import android.app.NotificationManager
 import android.os.Build
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessaging
+import com.konkuk.medicarecall.data.di.calendarModule
 import com.konkuk.medicarecall.data.di.homeDetailModule
 import com.konkuk.medicarecall.data.di.homeModule
 import com.konkuk.medicarecall.data.repository.FcmRepository
@@ -31,6 +32,7 @@ class App : Application(), KoinComponent {
         startKoin {
             androidContext(this@App)
             modules(
+                calendarModule,
                 homeModule,
                 homeDetailModule,
             )

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/CalendarModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/CalendarModule.kt
@@ -1,0 +1,12 @@
+package com.konkuk.medicarecall.data.di
+
+import com.konkuk.medicarecall.ui.feature.calendar.viewmodel.CalendarViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val calendarModule = module {
+
+    viewModel {
+        CalendarViewModel()
+    }
+}

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/HomeDetailModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/HomeDetailModule.kt
@@ -1,0 +1,49 @@
+package com.konkuk.medicarecall.data.di
+
+import com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.viewmodel.GlucoseViewModel
+import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealViewModel
+import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.MedicineViewModel
+import com.konkuk.medicarecall.ui.feature.homedetail.sleep.viewmodel.SleepViewModel
+import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthViewModel
+import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.MentalViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val homeDetailModule = module {
+
+    viewModel {
+        GlucoseViewModel(
+            get()
+        )
+    }
+
+    viewModel {
+        MealViewModel(
+            get()
+        )
+    }
+
+    viewModel {
+        MedicineViewModel(
+            get()
+        )
+    }
+
+    viewModel {
+        SleepViewModel(
+            get()
+        )
+    }
+
+    viewModel {
+        HealthViewModel(
+            get()
+        )
+    }
+
+    viewModel {
+        MentalViewModel(
+            get()
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/HomeDetailModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/HomeDetailModule.kt
@@ -13,37 +13,37 @@ val homeDetailModule = module {
 
     viewModel {
         GlucoseViewModel(
-            get()
+            get(),
         )
     }
 
     viewModel {
         MealViewModel(
-            get()
+            get(),
         )
     }
 
     viewModel {
         MedicineViewModel(
-            get()
+            get(),
         )
     }
 
     viewModel {
         SleepViewModel(
-            get()
+            get(),
         )
     }
 
     viewModel {
         HealthViewModel(
-            get()
+            get(),
         )
     }
 
     viewModel {
         MentalViewModel(
-            get()
+            get(),
         )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
@@ -1,0 +1,22 @@
+package com.konkuk.medicarecall.data.di
+
+
+import androidx.lifecycle.SavedStateHandle
+import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val homeModule = module {
+
+    viewModel { (savedStateHandle: SavedStateHandle) ->
+        HomeViewModel(
+            eldersInfoRepository = get(),
+            homeRepository = get(),
+            eldersHealthInfoRepository = get(),
+            savedStateHandle = savedStateHandle
+            // 화면 재생성 및 프로세스 복구를 위해 elderId를 SavedStateHandle로 관리
+            // SavedStateHandle은 Android 전용으로 KMP 공용 대상이 아님
+        )
+    }
+}
+

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
@@ -13,8 +13,6 @@ val homeModule = module {
             homeRepository = get(),
             eldersHealthInfoRepository = get(),
             savedStateHandle = savedStateHandle,
-            // 화면 재생성 및 프로세스 복구를 위해 elderId를 SavedStateHandle로 관리
-            // SavedStateHandle은 Android 전용으로 KMP 공용 대상이 아님
-        )
+           )
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/di/HomeModule.kt
@@ -1,6 +1,5 @@
 package com.konkuk.medicarecall.data.di
 
-
 import androidx.lifecycle.SavedStateHandle
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -13,10 +12,9 @@ val homeModule = module {
             eldersInfoRepository = get(),
             homeRepository = get(),
             eldersHealthInfoRepository = get(),
-            savedStateHandle = savedStateHandle
+            savedStateHandle = savedStateHandle,
             // 화면 재생성 및 프로세스 복구를 위해 elderId를 SavedStateHandle로 관리
             // SavedStateHandle은 Android 전용으로 KMP 공용 대상이 아님
         )
     }
 }
-

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/GlucoseRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/GlucoseRepositoryImpl.kt
@@ -4,9 +4,8 @@ import com.konkuk.medicarecall.data.api.elders.GlucoseService
 import com.konkuk.medicarecall.data.dto.response.GlucoseResponseDto
 import com.konkuk.medicarecall.data.repository.GlucoseRepository
 import retrofit2.HttpException
-import javax.inject.Inject
 
-class GlucoseRepositoryImpl @Inject constructor(
+class GlucoseRepositoryImpl(
     private val glucoseService: GlucoseService,
 ) : GlucoseRepository {
     override suspend fun getGlucoseGraph(

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HealthRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HealthRepositoryImpl.kt
@@ -4,9 +4,8 @@ import com.konkuk.medicarecall.data.api.elders.HealthService
 import com.konkuk.medicarecall.data.repository.HealthRepository
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthUiState
 import java.time.LocalDate
-import javax.inject.Inject
 
-class HealthRepositoryImpl @Inject constructor(
+class HealthRepositoryImpl(
     private val healthService: HealthService,
 ) : HealthRepository {
     override suspend fun getHealthUiState(elderId: Int, date: LocalDate): Result<HealthUiState> =

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -6,9 +6,8 @@ import com.konkuk.medicarecall.data.dto.request.ImmediateCallRequestDto
 import com.konkuk.medicarecall.data.dto.response.HomeResponseDto
 import com.konkuk.medicarecall.data.repository.HomeRepository
 import retrofit2.HttpException
-import javax.inject.Inject
 
-class HomeRepositoryImpl @Inject constructor(
+class HomeRepositoryImpl(
     private val homeService: HomeService,
 ) : HomeRepository {
     override suspend fun requestImmediateCareCall(

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MealRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MealRepositoryImpl.kt
@@ -4,9 +4,8 @@ import com.konkuk.medicarecall.data.api.elders.MealService
 import com.konkuk.medicarecall.data.repository.MealRepository
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealUiState
 import java.time.LocalDate
-import javax.inject.Inject
 
-class MealRepositoryImpl @Inject constructor(
+class MealRepositoryImpl(
     private val mealService: MealService,
 ) : MealRepository {
     override suspend fun getMealUiStateList(elderId: Int, date: LocalDate): List<MealUiState> {

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MedicineRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MedicineRepositoryImpl.kt
@@ -7,9 +7,8 @@ import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.DoseStat
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.DoseStatusItem
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.MedicineUiState
 import java.time.LocalDate
-import javax.inject.Inject
 
-class MedicineRepositoryImpl @Inject constructor(
+class MedicineRepositoryImpl(
     private val medicineService: MedicineService,
     private val eldersHealthInfoRepository: EldersHealthInfoRepository,
 ) : MedicineRepository {

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MentalRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/MentalRepositoryImpl.kt
@@ -7,9 +7,8 @@ import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.Menta
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.LocalDate
-import javax.inject.Inject
 
-class MentalRepositoryImpl @Inject constructor(
+class MentalRepositoryImpl(
     private val mentalService: MentalService,
 ) : MentalRepository {
 

--- a/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/SleepRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/data/repositoryimpl/SleepRepositoryImpl.kt
@@ -11,9 +11,8 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
-import javax.inject.Inject
 
-class SleepRepositoryImpl @Inject constructor(
+class SleepRepositoryImpl(
     private val sleepService: SleepService,
 ) : SleepRepository {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
@@ -1,7 +1,6 @@
 package com.konkuk.medicarecall.ui.feature.calendar.viewmodel
 
 import androidx.lifecycle.ViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,7 +9,7 @@ import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
 import javax.inject.Inject
 
-@HiltViewModel
+
 class CalendarViewModel @Inject constructor() : ViewModel() {
 
     private val _selectedDate = MutableStateFlow(LocalDate.now())

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
@@ -7,9 +7,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
-import javax.inject.Inject
 
-class CalendarViewModel @Inject constructor() : ViewModel() {
+class CalendarViewModel : ViewModel() {
 
     private val _selectedDate = MutableStateFlow(LocalDate.now())
     val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/calendar/viewmodel/CalendarViewModel.kt
@@ -9,7 +9,6 @@ import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
 import javax.inject.Inject
 
-
 class CalendarViewModel @Inject constructor() : ViewModel() {
 
     private val _selectedDate = MutableStateFlow(LocalDate.now())

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
 import com.konkuk.medicarecall.R
@@ -68,11 +67,12 @@ import com.konkuk.medicarecall.ui.feature.home.viewmodel.MedicineUiState
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    homeViewModel: HomeViewModel = hiltViewModel(),
+    homeViewModel: HomeViewModel = koinViewModel(),
     navigateToMealDetailScreen: (Int) -> Unit,
     navigateToMedicineDetailScreen: (Int) -> Unit,
     navigateToSleepDetailScreen: (Int) -> Unit,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 
 data class ElderInfo(val id: Int, val name: String, val phone: String?)
 
-class HomeViewModel @Inject constructor(
+class HomeViewModel (
     private val eldersInfoRepository: EldersInfoRepository,
     private val homeRepository: HomeRepository,
     private val savedStateHandle: SavedStateHandle,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -20,11 +20,10 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
-import javax.inject.Inject
 
 data class ElderInfo(val id: Int, val name: String, val phone: String?)
 
-class HomeViewModel (
+class HomeViewModel(
     private val eldersInfoRepository: EldersInfoRepository,
     private val homeRepository: HomeRepository,
     private val savedStateHandle: SavedStateHandle,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.EldersHealthInfoRepository
 import com.konkuk.medicarecall.data.repository.EldersInfoRepository
 import com.konkuk.medicarecall.data.repository.HomeRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,7 +24,6 @@ import javax.inject.Inject
 
 data class ElderInfo(val id: Int, val name: String, val phone: String?)
 
-@HiltViewModel
 class HomeViewModel @Inject constructor(
     private val eldersInfoRepository: EldersInfoRepository,
     private val homeRepository: HomeRepository,

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/screen/GlucoseDetailScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,6 +47,7 @@ import com.konkuk.medicarecall.ui.model.GlucoseTiming
 import com.konkuk.medicarecall.ui.model.GraphDataPoint
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -56,7 +56,7 @@ fun GlucoseDetailScreen(
     modifier: Modifier = Modifier,
     elderId: Int,
     onBack: () -> Unit,
-    glucoseViewModel: GlucoseViewModel = hiltViewModel(),
+    glucoseViewModel: GlucoseViewModel = koinViewModel(),
 ) {
     val scrollState = rememberScrollState()
     val uiState by glucoseViewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
-
 class GlucoseViewModel @Inject constructor(
     private val glucoseRepository: GlucoseRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.GlucoseRepository
 import com.konkuk.medicarecall.ui.model.GlucoseTiming
 import com.konkuk.medicarecall.ui.model.GraphDataPoint
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,7 +15,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
-@HiltViewModel
+
 class GlucoseViewModel @Inject constructor(
     private val glucoseRepository: GlucoseRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
-class GlucoseViewModel @Inject constructor(
+class GlucoseViewModel (
     private val glucoseRepository: GlucoseRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/viewmodel/GlucoseViewModel.kt
@@ -13,9 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import javax.inject.Inject
 
-class GlucoseViewModel (
+class GlucoseViewModel(
     private val glucoseRepository: GlucoseRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/screen/MealDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/screen/MealDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -31,6 +30,7 @@ import com.konkuk.medicarecall.ui.feature.homedetail.meal.component.MealDetailCa
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.meal.viewmodel.MealViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -38,8 +38,8 @@ import java.time.LocalDate
 fun MealDetailScreen(
     elderId: Int,
     onBack: () -> Unit,
-    calendarViewModel: CalendarViewModel = hiltViewModel(),
-    mealViewModel: MealViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = koinViewModel(),
+    mealViewModel: MealViewModel = koinViewModel(),
 ) {
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
@@ -12,7 +12,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-
 class MealViewModel @Inject constructor(
     private val mealRepository: MealRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
@@ -10,9 +10,8 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-class MealViewModel (
+class MealViewModel(
     private val mealRepository: MealRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.MealRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -13,7 +12,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-@HiltViewModel
+
 class MealViewModel @Inject constructor(
     private val mealRepository: MealRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/meal/viewmodel/MealViewModel.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-class MealViewModel @Inject constructor(
+class MealViewModel (
     private val mealRepository: MealRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/screen/MedicineDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/screen/MedicineDetailScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -34,6 +33,7 @@ import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.DoseStat
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.MedicineUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.medicine.viewmodel.MedicineViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -41,8 +41,8 @@ import java.time.LocalDate
 fun MedicineDetailScreen(
     elderId: Int,
     onBack: () -> Unit,
-    calendarViewModel: CalendarViewModel = hiltViewModel(),
-    medicineViewModel: MedicineViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = koinViewModel(),
+    medicineViewModel: MedicineViewModel = koinViewModel(),
 ) {
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
@@ -11,9 +11,8 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-class MedicineViewModel (
+class MedicineViewModel(
     private val medicineRepository: MedicineRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
@@ -13,7 +13,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-
 class MedicineViewModel @Inject constructor(
     private val medicineRepository: MedicineRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-class MedicineViewModel @Inject constructor(
+class MedicineViewModel (
     private val medicineRepository: MedicineRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/medicine/viewmodel/MedicineViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.MedicineRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -14,7 +13,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-@HiltViewModel
+
 class MedicineViewModel @Inject constructor(
     private val medicineRepository: MedicineRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/screen/SleepDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/screen/SleepDetailScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -30,6 +29,7 @@ import com.konkuk.medicarecall.ui.feature.homedetail.sleep.component.SleepDetail
 import com.konkuk.medicarecall.ui.feature.homedetail.sleep.viewmodel.SleepUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.sleep.viewmodel.SleepViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -37,8 +37,8 @@ import java.time.LocalDate
 fun SleepDetailScreen(
     elderId: Int,
     onBack: () -> Unit,
-    calendarViewModel: CalendarViewModel = hiltViewModel(),
-    sleepViewModel: SleepViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = koinViewModel(),
+    sleepViewModel: SleepViewModel = koinViewModel(),
 ) {
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-class SleepViewModel @Inject constructor(
+class SleepViewModel (
     private val sleepRepository: SleepRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.SleepRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -13,7 +12,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-@HiltViewModel
+
 class SleepViewModel @Inject constructor(
     private val sleepRepository: SleepRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
@@ -10,9 +10,8 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-class SleepViewModel (
+class SleepViewModel(
     private val sleepRepository: SleepRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/sleep/viewmodel/SleepViewModel.kt
@@ -12,7 +12,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-
 class SleepViewModel @Inject constructor(
     private val sleepRepository: SleepRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -32,14 +31,15 @@ import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.component.State
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.statehealth.viewmodel.HealthViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @Composable
 fun StateHealthDetailScreen(
     elderId: Int,
     onBack: () -> Unit,
-    calendarViewModel: CalendarViewModel = hiltViewModel(),
-    healthViewModel: HealthViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = koinViewModel(),
+    healthViewModel: HealthViewModel = koinViewModel(),
 ) {
     val isLoading = healthViewModel.isLoading.collectAsStateWithLifecycle()
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-class HealthViewModel @Inject constructor(
+class HealthViewModel (
     private val healthRepository: HealthRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
@@ -11,7 +11,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-
 class HealthViewModel @Inject constructor(
     private val healthRepository: HealthRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
@@ -9,9 +9,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-class HealthViewModel (
+class HealthViewModel(
     private val healthRepository: HealthRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.HealthRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -12,7 +11,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-@HiltViewModel
+
 class HealthViewModel @Inject constructor(
     private val healthRepository: HealthRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/screen/StateMentalDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/screen/StateMentalDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -31,6 +30,7 @@ import com.konkuk.medicarecall.ui.feature.homedetail.statemental.component.State
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.MentalUiState
 import com.konkuk.medicarecall.ui.feature.homedetail.statemental.viewmodel.MentalViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.koin.androidx.compose.koinViewModel
 import java.time.LocalDate
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -38,8 +38,8 @@ import java.time.LocalDate
 fun StateMentalDetailScreen(
     elderId: Int,
     onBack: () -> Unit,
-    calendarViewModel: CalendarViewModel = hiltViewModel(),
-    mentalViewModel: MentalViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = koinViewModel(),
+    mentalViewModel: MentalViewModel = koinViewModel(),
 ) {
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
@@ -11,7 +11,7 @@ import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class MentalViewModel (
+class MentalViewModel(
     private val mentalRepository: MentalRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
@@ -12,7 +12,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-
 class MentalViewModel @Inject constructor(
     private val mentalRepository: MentalRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.MentalRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -13,7 +12,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-@HiltViewModel
+
 class MentalViewModel @Inject constructor(
     private val mentalRepository: MentalRepository,
 ) : ViewModel() {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statemental/viewmodel/MentalViewModel.kt
@@ -10,9 +10,8 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-class MentalViewModel @Inject constructor(
+class MentalViewModel (
     private val mentalRepository: MentalRepository,
 ) : ViewModel() {
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.hilt) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.google.services) apply false
 }
-


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #210 

## 📙 작업 설명
- Home, HomeDetail, Calendar 의 뷰모델 DI를 Hilt->Koin 으로 전환
- Home, HomeDetail, Calendar 전용 Koin Module 정의
- 각 화면의 hilt 호출을 제거하고 koin으로 수정
- Hilt, Inject 어노테이션 제거

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 앱의 의존성 주입이 Hilt에서 Koin으로 전환되어 앱 초기화와 ViewModel 제공 방식이 Koin 기반으로 변경되었습니다.
  * 여러 화면(홈, 상세, 캘린더 등)의 기본 ViewModel 획득이 Koin으로 통일되어 인스턴스 제공 방식이 일관화되었습니다.

* **Chores**
  * 빌드·정적분석 설정에서 Hilt 관련 항목이 제거되고 Koin 의존성 및 모듈 등록이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->