### PR TITLE
[Refactor] 홈 및 상세 화면 uiState 감싸기

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -81,7 +81,6 @@ fun HomeScreen(
     navigateToGlucoseDetailScreen: (Int) -> Unit,
     mainBackStackEntry: NavBackStackEntry,
 ) {
-
     val screenUiState by homeViewModel.homeScreenUiState.collectAsStateWithLifecycle()
 
     var dropdownOpened by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/screen/HomeScreen.kt
@@ -81,10 +81,8 @@ fun HomeScreen(
     navigateToGlucoseDetailScreen: (Int) -> Unit,
     mainBackStackEntry: NavBackStackEntry,
 ) {
-    val homeUiState by homeViewModel.homeUiState.collectAsStateWithLifecycle()
-    val elderInfoList by homeViewModel.elderInfoList.collectAsStateWithLifecycle()
-    val elderNameList by homeViewModel.elderNameList.collectAsStateWithLifecycle()
-    val selectedElderId by homeViewModel.selectedElderId.collectAsStateWithLifecycle()
+
+    val screenUiState by homeViewModel.homeScreenUiState.collectAsStateWithLifecycle()
 
     var dropdownOpened by remember { mutableStateOf(false) }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -105,9 +103,9 @@ fun HomeScreen(
 
     HomeScreenLayout(
         modifier = modifier,
-        homeUiState = homeUiState,
-        elderInfoList = elderInfoList,
-        selectedElderId = selectedElderId,
+        homeUiState = screenUiState.homeData,
+        elderInfoList = screenUiState.elderInfoList,
+        selectedElderId = screenUiState.selectedElderId,
         isRefreshing = isRefreshing,
         dropdownOpened = dropdownOpened,
         onDropdownClick = { dropdownOpened = true },
@@ -116,17 +114,17 @@ fun HomeScreen(
             homeViewModel.selectElder(selectedName)
             dropdownOpened = false
         },
-        navigateToMealDetailScreen = { selectedElderId?.let(navigateToMealDetailScreen) },
-        navigateToMedicineDetailScreen = { selectedElderId?.let(navigateToMedicineDetailScreen) },
-        navigateToSleepDetailScreen = { selectedElderId?.let(navigateToSleepDetailScreen) },
-        navigateToStateHealthDetailScreen = { selectedElderId?.let(navigateToStateHealthDetailScreen) },
-        navigateToStateMentalDetailScreen = { selectedElderId?.let(navigateToStateMentalDetailScreen) },
-        navigateToGlucoseDetailScreen = { selectedElderId?.let(navigateToGlucoseDetailScreen) },
+        navigateToMealDetailScreen = { screenUiState.selectedElderId?.let(navigateToMealDetailScreen) },
+        navigateToMedicineDetailScreen = { screenUiState.selectedElderId?.let(navigateToMedicineDetailScreen) },
+        navigateToSleepDetailScreen = { screenUiState.selectedElderId?.let(navigateToSleepDetailScreen) },
+        navigateToStateHealthDetailScreen = { screenUiState.selectedElderId?.let(navigateToStateHealthDetailScreen) },
+        navigateToStateMentalDetailScreen = { screenUiState.selectedElderId?.let(navigateToStateMentalDetailScreen) },
+        navigateToGlucoseDetailScreen = { screenUiState.selectedElderId?.let(navigateToGlucoseDetailScreen) },
 
         navigateToAlarm = {},
 
         snackbarHostState = snackbarHostState,
-        isLoading = homeUiState.isLoading,
+        isLoading = screenUiState.homeData.isLoading,
         onFabClick = {
             scope.launch {
                 snackbarHostState.showSnackbar("케어콜이 곧 연결됩니다. 잠시만 기다려 주세요.")

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
@@ -91,3 +91,22 @@ data class DoseStatusUiState(
     val time: String, // "아침", "점심", "저녁"
     val taken: Boolean?, // true: 먹음, false: 안 먹음, null: 미기록
 )
+
+/**
+ * HomeScreen 전체의 통합 UiState
+ */
+data class HomeScreenUiState(
+    val homeData: HomeUiState,               // 홈 화면 메인 데이터
+    val elderInfoList: List<ElderInfo>,      // 어르신 전체 목록
+    val selectedElderId: Int?,               // 현재 선택된 어르신 ID
+) {
+    companion object {
+        val EMPTY = HomeScreenUiState(
+            homeData = HomeUiState.EMPTY,
+            elderInfoList = emptyList(),
+            selectedElderId = null,
+        )
+    }
+}
+
+data class ElderInfo(val id: Int, val name: String, val phone: String?)

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeUiState.kt
@@ -96,9 +96,9 @@ data class DoseStatusUiState(
  * HomeScreen 전체의 통합 UiState
  */
 data class HomeScreenUiState(
-    val homeData: HomeUiState,               // 홈 화면 메인 데이터
-    val elderInfoList: List<ElderInfo>,      // 어르신 전체 목록
-    val selectedElderId: Int?,               // 현재 선택된 어르신 ID
+    val homeData: HomeUiState, // 홈 화면 메인 데이터
+    val elderInfoList: List<ElderInfo>, // 어르신 전체 목록
+    val selectedElderId: Int?, // 현재 선택된 어르신 ID
 ) {
     companion object {
         val EMPTY = HomeScreenUiState(

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -15,14 +15,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
 import com.konkuk.medicarecall.data.exception.HttpException
-
-data class ElderInfo(val id: Int, val name: String, val phone: String?)
 
 @KoinViewModel
 class HomeViewModel(
@@ -63,21 +62,36 @@ class HomeViewModel(
 
     // 홈 화면 상태 (isLoading 포함)
     private val _homeUiState = MutableStateFlow(HomeUiState.Companion.EMPTY)
-    val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
 
     // 어르신 전체 목록
     private val _elderInfoList = MutableStateFlow<List<ElderInfo>>(emptyList())
-    val elderInfoList: StateFlow<List<ElderInfo>> = _elderInfoList.asStateFlow()
-
-//    드롭다운에 표시할 어르신 이름 목록
-//    val elderNameList: StateFlow<List<String>> = _elderInfoList.mapState { list ->
-//        list.map { it.name }
-//    }
 
     // 현재 선택된 어르신 ID
     private val _selectedElderId = MutableStateFlow<Int?>(
         savedStateHandle.get<Int?>(KEY_SELECTED_ELDER_ID),
     )
+
+    /**
+     * HomeScreen 전용 통합 StateFlow
+     */
+    val homeScreenUiState: StateFlow<HomeScreenUiState> = combine(
+        _homeUiState,
+        _elderInfoList,
+        _selectedElderId,
+    ) { homeData, elderInfos, selectedId ->
+        HomeScreenUiState(
+            homeData = homeData,
+            elderInfoList = elderInfos,
+            selectedElderId = selectedId,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = HomeScreenUiState.EMPTY,
+    )
+
+    val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
+    val elderInfoList: StateFlow<List<ElderInfo>> = _elderInfoList.asStateFlow()
     val selectedElderId: StateFlow<Int?> = _selectedElderId.asStateFlow()
 
     init {

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -41,15 +41,14 @@ fun StateHealthDetailScreen(
     calendarViewModel: CalendarViewModel = koinViewModel(),
     healthViewModel: HealthViewModel = koinViewModel(),
 ) {
-    val isLoading = healthViewModel.isLoading.collectAsStateWithLifecycle()
+
+    val healthScreenUiState by healthViewModel.healthScreenUiState.collectAsStateWithLifecycle()
+    val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
 
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         calendarViewModel.resetToToday()
     }
-
-    val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
-    val health by healthViewModel.health.collectAsStateWithLifecycle()
 
     // 날짜/어르신 변경 시마다 로드
     LaunchedEffect(elderId, selectedDate) {
@@ -58,12 +57,12 @@ fun StateHealthDetailScreen(
         }
     }
 
-    if (!isLoading.value)
+    if (!healthScreenUiState.isLoading)
         StateHealthDetailScreenLayout(
             modifier = Modifier,
             onBack = onBack,
             selectedDate = selectedDate,
-            health = health,
+            health = healthScreenUiState.healthData,
             weekDates = calendarViewModel.getCurrentWeekDates(),
             onDateSelected = { calendarViewModel.selectDate(it) },
             onMonthClick = { /* 모달 열기 */ },

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -41,7 +41,6 @@ fun StateHealthDetailScreen(
     calendarViewModel: CalendarViewModel = koinViewModel(),
     healthViewModel: HealthViewModel = koinViewModel(),
 ) {
-
     val healthScreenUiState by healthViewModel.healthScreenUiState.collectAsStateWithLifecycle()
     val selectedDate by calendarViewModel.selectedDate.collectAsStateWithLifecycle()
 

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthUiState.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthUiState.kt
@@ -13,3 +13,18 @@ data class HealthUiState(
         )
     }
 }
+
+/**
+ * StateHealthDetailScreen 전용 통합 UiState
+ */
+data class HealthScreenUiState(
+    val isLoading: Boolean,
+    val healthData: HealthUiState,
+) {
+    companion object {
+        val EMPTY = HealthScreenUiState(
+            isLoading = true,
+            healthData = HealthUiState.EMPTY,
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/viewmodel/HealthViewModel.kt
@@ -5,7 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.HealthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
 import java.time.LocalDate
@@ -21,9 +24,26 @@ class HealthViewModel(
     }
 
     private val _isLoading = MutableStateFlow(true)
-    val isLoading: StateFlow<Boolean> = _isLoading
-
     private val _health = MutableStateFlow(HealthUiState.Companion.EMPTY)
+
+    /**
+     * StateHealthDetailScreen 전용 통합 StateFlow
+     */
+    val healthScreenUiState: StateFlow<HealthScreenUiState> = combine(
+        _isLoading,
+        _health,
+    ) { loading, healthData ->
+        HealthScreenUiState(
+            isLoading = loading,
+            healthData = healthData,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = HealthScreenUiState.EMPTY,
+    )
+
+    val isLoading: StateFlow<Boolean> = _isLoading
     val health: StateFlow<HealthUiState> = _health
 
     fun loadHealthDataForDate(elderId: Int, date: LocalDate) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #237 

## 📙 작업 설명
  #### 1. HomeScreen                                                                                                                           
  - `HomeScreenUiState` 추가하여 3개 StateFlow를 하나로 통합                                                                                   
  - homeData, elderInfoList, selectedElderId 결합                                                        
  - 사용하지 않던 elderNameList 구독 제거                                                                                                      
                                                                                                                                               
  #### 2. StateHealthDetailScreen                                                                                                              
  - `HealthScreenUiState` 추가하여 2개 StateFlow를 하나로 통합                                                                                 
  - isLoading과 healthData 결합                                                         

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 캘린더뷰모델의 경우 앞에 pr이 있어서 리팩토링하지 않았습니다
- 나머지 화면들은 한개의 stateflow만 구독하므로 통합에서 제외했습니다
- 제가 진행한 부분이 맞는지 체크해주시면 감사하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 홈 화면과 건강 상세 화면의 상태 관리를 통합해 UI 데이터 일관성과 안정성을 개선했습니다.
  * 로딩 표시와 선택된 대상(어르신) 관리가 하나의 집계된 상태로 통일되어 더 예측 가능한 동작을 제공합니다.
* **New Features**
  * 어르신 목록/이름 추출이 개선되어 드롭다운 및 네비게이션 동작이 더 원활해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->