### PR TITLE
[Refactor] : Glucose 관련 java 함수 쓰인 부분 리팩토링 진행

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
@@ -1,18 +1,18 @@
 package com.konkuk.medicarecall.ui.feature.homedetail.glucoselevel.component
 
 import android.annotation.SuppressLint
-import android.graphics.Color
-import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
@@ -20,14 +20,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.konkuk.medicarecall.domain.util.now
 import com.konkuk.medicarecall.ui.common.util.GlucoseLevel
 import com.konkuk.medicarecall.ui.common.util.classifyGlucose
@@ -37,8 +38,7 @@ import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.minus
-import kotlinx.datetime.toJavaLocalDate
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.number
 import kotlin.math.max
 
 @Composable
@@ -160,8 +160,9 @@ fun GlucoseGraph(
                     Row(modifier = Modifier.width(totalGraphWidth)) { // 동적 너비 사용
                         data.forEach { pointData ->
                             Text(
-                                text = pointData.date.toJavaLocalDate().format(DateTimeFormatter.ofPattern("M.d")),
-                                modifier = Modifier.width(sectionWidth), // 동적 섹션 너비 사용
+                                // [수정] monthNumber와 dayOfMonth 사용
+                                text = "${pointData.date.month.number}.${pointData.date.day}",
+                                modifier = Modifier.width(sectionWidth),
                                 style = labelStyle,
                                 color = colors.gray4,
                                 textAlign = TextAlign.Center,
@@ -171,48 +172,33 @@ fun GlucoseGraph(
                 }
             }
         }
-        // Y축 라벨 (오른쪽에 고정)
-        Canvas(
+
+        Box(
             modifier = Modifier
                 .width(40.dp)
-                .height(graphDrawingHeightDp),
+                .height(graphDrawingHeightDp)
         ) {
-            // 그래프와 동일한 Y좌표 계산 방식을 사용
+            val density = LocalDensity.current
+            val heightPx = with(density) { graphDrawingHeightDp.toPx() }
+
             fun valueToY(v: Float): Float {
                 val ratio = ((v - minGlucose) / (maxGlucose - minGlucose)).coerceIn(0f, 1f)
-                return size.height * (1f - ratio)
+                return heightPx * (1f - ratio)
             }
-            // Paint를 사용하여 Canvas에 직접 글씨를 씀
-            val paint = Paint().apply {
-                color = Color.GRAY
-                textSize = labelStyle.fontSize.toPx()
-                textAlign = Paint.Align.LEFT
+
+            listOf(200, 130, 90, 60).forEach { value ->
+                val yPosPx = valueToY(value.toFloat())
+                val yPosDp = with(density) { yPosPx.toDp() }
+
+                Text(
+                    text = value.toString(),
+                    style = labelStyle.copy(fontSize = 12.sp),
+                    color = Color.Gray,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .offset(x = 8.dp, y = yPosDp - 7.dp)
+                )
             }
-            val labelX = 8.dp.toPx()
-            drawContext.canvas.nativeCanvas.drawText(
-                "200",
-                labelX,
-                valueToY(200f) + 5.dp.toPx(),
-                paint,
-            )
-            drawContext.canvas.nativeCanvas.drawText(
-                "130",
-                labelX,
-                valueToY(130f) + 5.dp.toPx(),
-                paint,
-            )
-            drawContext.canvas.nativeCanvas.drawText(
-                "90",
-                labelX,
-                valueToY(90f) + 5.dp.toPx(),
-                paint,
-            )
-            drawContext.canvas.nativeCanvas.drawText(
-                "60",
-                labelX,
-                valueToY(60f) + 5.dp.toPx(),
-                paint,
-            )
         }
     }
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
@@ -176,7 +176,7 @@ fun GlucoseGraph(
         Box(
             modifier = Modifier
                 .width(40.dp)
-                .height(graphDrawingHeightDp)
+                .height(graphDrawingHeightDp),
         ) {
             val density = LocalDensity.current
             val heightPx = with(density) { graphDrawingHeightDp.toPx() }
@@ -196,7 +196,7 @@ fun GlucoseGraph(
                     color = Color.Gray,
                     modifier = Modifier
                         .align(Alignment.TopStart)
-                        .offset(x = 8.dp, y = yPosDp - 7.dp)
+                        .offset(x = 8.dp, y = yPosDp - 7.dp),
                 )
             }
         }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseGraph.kt
@@ -160,7 +160,6 @@ fun GlucoseGraph(
                     Row(modifier = Modifier.width(totalGraphWidth)) { // 동적 너비 사용
                         data.forEach { pointData ->
                             Text(
-                                // [수정] monthNumber와 dayOfMonth 사용
                                 text = "${pointData.date.month.number}.${pointData.date.day}",
                                 modifier = Modifier.width(sectionWidth),
                                 style = labelStyle,
@@ -176,7 +175,7 @@ fun GlucoseGraph(
         Box(
             modifier = Modifier
                 .width(40.dp)
-                .height(graphDrawingHeightDp)
+                .height(graphDrawingHeightDp),
         ) {
             val density = LocalDensity.current
             val heightPx = with(density) { graphDrawingHeightDp.toPx() }
@@ -196,7 +195,7 @@ fun GlucoseGraph(
                     color = Color.Gray,
                     modifier = Modifier
                         .align(Alignment.TopStart)
-                        .offset(x = 8.dp, y = yPosDp - 7.dp)
+                        .offset(x = 8.dp, y = yPosDp - 7.dp),
                 )
             }
         }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseListItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/feature/homedetail/glucoselevel/component/GlucoseListItem.kt
@@ -16,10 +16,9 @@ import androidx.compose.ui.unit.dp
 import com.konkuk.medicarecall.domain.util.now
 import com.konkuk.medicarecall.ui.model.GlucoseTiming
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.toJavaLocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
+import kotlinx.datetime.number
 
 @Composable
 fun GlucoseListItem(
@@ -29,8 +28,19 @@ fun GlucoseListItem(
     value: Int,
     timing: GlucoseTiming,
 ) {
-    val formatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
-    val formattedDate = date.toJavaLocalDate().format(formatter)
+    val dayOfWeekString = when (date.dayOfWeek) {
+        DayOfWeek.MONDAY -> "월"
+        DayOfWeek.TUESDAY -> "화"
+        DayOfWeek.WEDNESDAY -> "수"
+        DayOfWeek.THURSDAY -> "목"
+        DayOfWeek.FRIDAY -> "금"
+        DayOfWeek.SATURDAY -> "토"
+        DayOfWeek.SUNDAY -> "일"
+    }
+
+    // 예: "5월 20일 (월)"
+    val formattedDate = "${date.month.number}월 ${date.day}일 ($dayOfWeekString)"
+
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.Start,


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #255 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
1. java.time → kotlinx-datetime 마이그레이션

영향 범위: GlucoseGraph, GlucoseListItem, SleepResponseDto Mapper

JDK 의존적인 java.time.LocalDate, DateTimeFormatter를 제거했습니다.

대신 kotlinx-datetime을 사용하여 날짜를 처리하고, 포맷팅 로직을 코틀린 문자열 템플릿 및 확장 함수로 직접 구현하여 플랫폼 독립성을 확보했습니다.

2. GlucoseGraph 컴포넌트 리팩토링 (Android View 의존성 제거)

기존: nativeCanvas, android.graphics.Paint, drawText를 사용하여 Y축 라벨을 그림.

변경: Jetpack Compose의 표준 컴포넌트인 Box와 Text를 사용하여 구현.

이점:

android.graphics 의존성 제거로 비 Android 플랫폼(iOS 등) 호환성 확보.

명령형 그리기 방식에서 선언형 UI(Compose) 방식으로 변경하여 코드 가독성 및 유지보수성 향상.

3. Data Mapper 리팩토링

SleepResponseDto에서 시간을 변환하는 로직을 확장 함수로 분리하고, 불필요한 Java 타입 변환 과정을 제거하여 순수 코틀린 로직으로 간소화했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 향후 KMP(Kotlin Multiplatform) 도입을 대비하여, UI 및 데이터 매핑 로직에서 JVM(Java) 및 Android 프레임워크에 대한 강한 의존성을 제거
- 기존 java.time 패키지와 android.graphics 패키지를 사용하는 로직을 Pure Kotlin(kotlinx-datetime) 및 Pure Compose 방식으로 대체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 포도당 그래프의 축 및 레이블 렌더링을 텍스트 기반으로 개선해 표시 안정성과 성능을 향상시켰습니다.
  * 그래프 크기 계산을 개선해 다양한 화면에서 레이블 위치가 더 일관되게 표시됩니다.
  * 목록의 날짜 표기를 한국어 요일 형식(예: "월월 일 (요일)")으로 일관되게 표시하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->